### PR TITLE
feat: add NanoGPT OpenClaw provider plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 deadronos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,31 @@
 NanoGPT provider plugin for OpenClaw with API-key auth, dynamic model discovery,
 and automatic subscription or pay-as-you-go routing.
 
-## Install
+## Install from npm
 
 ```bash
 openclaw plugins install @deadronos/openclaw-nanogpt-provider
+```
+
+## Install locally without publishing
+
+Install directly from the repo checkout:
+
+```bash
+openclaw plugins install /Users/openclaw/Github/nanogpt-provider-openclaw
+```
+
+Or build a tarball and install that exact package artifact:
+
+```bash
+npm pack
+openclaw plugins install ./deadronos-openclaw-nanogpt-provider-0.1.0.tgz
+```
+
+Restart the gateway after install:
+
+```bash
+openclaw gateway restart
 ```
 
 ## Auth
@@ -47,3 +68,12 @@ openclaw onboard --nanogpt-api-key your_key_here
 - `routingMode`: `auto`, `subscription`, `paygo`
 - `catalogSource`: `auto`, `canonical`, `subscription`, `paid`, `personalized`
 - `provider`: optional NanoGPT upstream provider id
+
+## Publish to npm
+
+```bash
+npm test
+npm run typecheck
+npm pack --dry-run
+npm publish --access public
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# NanoGPT Provider for OpenClaw
+
+NanoGPT provider plugin for OpenClaw with API-key auth, dynamic model discovery,
+and automatic subscription or pay-as-you-go routing.
+
+## Install
+
+```bash
+openclaw plugins install @deadronos/openclaw-nanogpt-provider
+```
+
+## Auth
+
+Set:
+
+```bash
+export NANOGPT_API_KEY=your_key_here
+```
+
+Or onboard with:
+
+```bash
+openclaw onboard --nanogpt-api-key your_key_here
+```
+
+## Config
+
+```json5
+{
+  plugins: {
+    entries: {
+      nanogpt: {
+        enabled: true,
+        config: {
+          routingMode: "auto",
+          catalogSource: "auto",
+          provider: "openrouter"
+        }
+      }
+    }
+  }
+}
+```
+
+## Options
+
+- `routingMode`: `auto`, `subscription`, `paygo`
+- `catalogSource`: `auto`, `canonical`, `subscription`, `paid`, `personalized`
+- `provider`: optional NanoGPT upstream provider id

--- a/api.ts
+++ b/api.ts
@@ -1,0 +1,24 @@
+export {
+  NANOGPT_BASE_URL,
+  NANOGPT_DEFAULT_MODEL_ID,
+  NANOGPT_DEFAULT_MODEL_REF,
+  NANOGPT_FALLBACK_MODELS,
+  NANOGPT_PAID_BASE_URL,
+  NANOGPT_PERSONALIZED_BASE_URL,
+  NANOGPT_PROVIDER_ID,
+  NANOGPT_SUBSCRIPTION_BASE_URL,
+  buildNanoGptModelDefinition,
+} from "./models.js";
+export { applyNanoGptConfig, applyNanoGptProviderConfig } from "./onboard.js";
+export { buildNanoGptProvider } from "./provider-catalog.js";
+export {
+  buildNanoGptRequestHeaders,
+  discoverNanoGptModels,
+  getNanoGptConfig,
+  probeNanoGptSubscription,
+  resetNanoGptRuntimeState,
+  resolveCatalogBaseUrl,
+  resolveCatalogSource,
+  resolveNanoGptRoutingMode,
+  resolveRequestBaseUrl,
+} from "./runtime.js";

--- a/docs/superpowers/plans/2026-04-08-nanogpt-provider-plugin.md
+++ b/docs/superpowers/plans/2026-04-08-nanogpt-provider-plugin.md
@@ -5,8 +5,7 @@
 ## Goal
 
 Create a publishable external native OpenClaw plugin in
-`/Users/openclaw/Github/nanogpt-provider-openclaw` that registers a `nanogpt`
-provider with:
+`nanogpt-provider-openclaw` that registers a `nanogpt` provider with:
 
 - API-key auth via `NANOGPT_API_KEY`
 - OpenAI-compatible transport

--- a/docs/superpowers/plans/2026-04-08-nanogpt-provider-plugin.md
+++ b/docs/superpowers/plans/2026-04-08-nanogpt-provider-plugin.md
@@ -1,0 +1,1110 @@
+# NanoGPT Provider Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Goal
+
+Create a publishable external native OpenClaw plugin in
+`/Users/openclaw/Github/nanogpt-provider-openclaw` that registers a `nanogpt`
+provider with:
+
+- API-key auth via `NANOGPT_API_KEY`
+- OpenAI-compatible transport
+- dynamic NanoGPT model discovery
+- `routingMode: auto | subscription | paygo`
+- `catalogSource: auto | canonical | subscription | paid | personalized`
+- optional per-request upstream provider selection
+- graceful fallback to a small static model catalog
+
+## File Map
+
+- `package.json`
+  - Package metadata, scripts, OpenClaw metadata, and dev dependencies
+- `tsconfig.json`
+  - TypeScript configuration for ESM plugin development
+- `openclaw.plugin.json`
+  - Plugin manifest, auth metadata, and config schema
+- `index.ts`
+  - Main plugin registration entrypoint
+- `api.ts`
+  - Curated local export surface
+- `models.ts`
+  - NanoGPT endpoint constants, fallback models, response types, and model parsing
+- `runtime.ts`
+  - Subscription probing cache, routing resolution, discovery fetch, and request decoration helpers
+- `provider-catalog.ts`
+  - Build provider config and catalog result from NanoGPT state
+- `onboard.ts`
+  - Default model aliasing and apply-config helpers
+- `index.test.ts`
+  - Provider registration behavior tests
+- `runtime.test.ts`
+  - Routing, subscription probe, discovery, and request decoration tests
+- `provider-catalog.test.ts`
+  - Catalog construction and fallback tests
+- `README.md`
+  - Install, configure, and use instructions
+
+## Implementation Tasks
+
+- [ ] **Step 1: Create the package manifest**
+
+Create `package.json` with the initial package metadata and scripts:
+
+```json
+{
+  "name": "@deadronos/openclaw-nanogpt-provider",
+  "version": "0.1.0",
+  "description": "OpenClaw NanoGPT provider plugin",
+  "type": "module",
+  "license": "MIT",
+  "files": [
+    "index.ts",
+    "api.ts",
+    "models.ts",
+    "runtime.ts",
+    "provider-catalog.ts",
+    "onboard.ts",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.24-beta.2"
+  },
+  "devDependencies": {
+    "openclaw": "^2026.4.5",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4",
+    "@types/node": "^24.6.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "providers": [
+      "nanogpt"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2",
+      "minGatewayVersion": "2026.3.24-beta.2"
+    },
+    "build": {
+      "openclawVersion": "2026.4.5",
+      "pluginSdkVersion": "2026.4.5"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create the TypeScript config**
+
+Create `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts"]
+}
+```
+
+- [ ] **Step 3: Install dependencies**
+
+Run:
+
+```bash
+npm install
+```
+
+Expected:
+
+- `package-lock.json` is created
+- `node_modules/` is populated
+
+- [ ] **Step 4: Create the plugin manifest**
+
+Create `openclaw.plugin.json`:
+
+```json
+{
+  "id": "nanogpt",
+  "name": "NanoGPT",
+  "description": "NanoGPT provider plugin for OpenClaw",
+  "providers": ["nanogpt"],
+  "providerAuthEnvVars": {
+    "nanogpt": ["NANOGPT_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "nanogpt",
+      "method": "api-key",
+      "choiceId": "nanogpt-api-key",
+      "choiceLabel": "NanoGPT API key",
+      "groupId": "nanogpt",
+      "groupLabel": "NanoGPT",
+      "groupHint": "Subscription or pay-as-you-go",
+      "optionKey": "nanogptApiKey",
+      "cliFlag": "--nanogpt-api-key",
+      "cliOption": "--nanogpt-api-key <key>",
+      "cliDescription": "NanoGPT API key"
+    }
+  ],
+  "uiHints": {
+    "routingMode": {
+      "label": "Routing Mode",
+      "help": "Choose auto, subscription, or paygo routing."
+    },
+    "catalogSource": {
+      "label": "Catalog Source",
+      "help": "Choose how NanoGPT model discovery should work."
+    },
+    "provider": {
+      "label": "Provider Override",
+      "help": "Optional NanoGPT upstream provider id for paygo provider selection."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "routingMode": {
+        "type": "string",
+        "enum": ["auto", "subscription", "paygo"]
+      },
+      "catalogSource": {
+        "type": "string",
+        "enum": ["auto", "canonical", "subscription", "paid", "personalized"]
+      },
+      "provider": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Write the first manifest-focused test**
+
+Create `index.test.ts` with the first failing test:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "openclaw/test/helpers/plugins/plugin-registration.js";
+import nanogptPlugin from "./index.js";
+
+describe("nanogpt provider registration", () => {
+  it("registers the nanogpt provider", async () => {
+    const provider = await registerSingleProviderPlugin(nanogptPlugin);
+
+    expect(provider.id).toBe("nanogpt");
+    expect(provider.label).toBe("NanoGPT");
+    expect(provider.docsPath).toBe("/providers/models");
+  });
+});
+```
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+Run:
+
+```bash
+npm test -- index.test.ts
+```
+
+Expected:
+
+- FAIL because `index.ts` does not exist yet
+
+- [ ] **Step 7: Create model constants and fallback catalog**
+
+Create `models.ts`:
+
+```ts
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const NANOGPT_PROVIDER_ID = "nanogpt";
+export const NANOGPT_BASE_URL = "https://nano-gpt.com/api/v1";
+export const NANOGPT_SUBSCRIPTION_BASE_URL = "https://nano-gpt.com/api/subscription/v1";
+export const NANOGPT_PAID_BASE_URL = "https://nano-gpt.com/api/paid/v1";
+export const NANOGPT_PERSONALIZED_BASE_URL = "https://nano-gpt.com/api/personalized/v1";
+export const NANOGPT_DEFAULT_MODEL_ID = "gpt-5.4-mini";
+export const NANOGPT_DEFAULT_MODEL_REF = `${NANOGPT_PROVIDER_ID}/${NANOGPT_DEFAULT_MODEL_ID}`;
+
+export const NANOGPT_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+export const NANOGPT_FALLBACK_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: NANOGPT_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 32768,
+  },
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: NANOGPT_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 32768,
+  },
+  {
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: NANOGPT_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 32768,
+  }
+];
+
+export type NanoGptRoutingMode = "auto" | "subscription" | "paygo";
+export type NanoGptCatalogSource =
+  | "auto"
+  | "canonical"
+  | "subscription"
+  | "paid"
+  | "personalized";
+
+export interface NanoGptPluginConfig {
+  routingMode?: NanoGptRoutingMode;
+  catalogSource?: NanoGptCatalogSource;
+  provider?: string;
+}
+
+export interface NanoGptModelEntry {
+  id?: string;
+  canonicalId?: string;
+  name?: string;
+  displayName?: string;
+  reasoning?: boolean;
+  vision?: boolean;
+  contextWindow?: number;
+  maxTokens?: number;
+  pricing?: {
+    inputPer1kTokens?: number;
+    outputPer1kTokens?: number;
+  };
+}
+
+function toPerMillion(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return value * 1000;
+}
+
+export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefinitionConfig | null {
+  const id = String(entry.canonicalId ?? entry.id ?? "").trim();
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    name: String(entry.displayName ?? entry.name ?? id),
+    reasoning: Boolean(entry.reasoning),
+    input: entry.vision ? ["text", "image"] : ["text"],
+    cost: {
+      input: toPerMillion(entry.pricing?.inputPer1kTokens),
+      output: toPerMillion(entry.pricing?.outputPer1kTokens),
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow:
+      typeof entry.contextWindow === "number" && entry.contextWindow > 0
+        ? entry.contextWindow
+        : 200000,
+    maxTokens:
+      typeof entry.maxTokens === "number" && entry.maxTokens > 0 ? entry.maxTokens : 32768,
+  };
+}
+```
+
+- [ ] **Step 8: Add runtime tests for routing and discovery helpers**
+
+Create `runtime.test.ts` with a first red test:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { resolveNanoGptRoutingMode } from "./runtime.js";
+
+describe("resolveNanoGptRoutingMode", () => {
+  it("returns explicit paygo without probing", async () => {
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "paygo" },
+        apiKey: "test-key",
+      }),
+    ).resolves.toBe("paygo");
+  });
+});
+```
+
+- [ ] **Step 9: Run the tests to verify they fail**
+
+Run:
+
+```bash
+npm test -- index.test.ts runtime.test.ts
+```
+
+Expected:
+
+- FAIL because `runtime.ts` and `index.ts` do not exist yet
+
+- [ ] **Step 10: Implement runtime helpers**
+
+Create `runtime.ts`:
+
+```ts
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  NANOGPT_BASE_URL,
+  NANOGPT_FALLBACK_MODELS,
+  NANOGPT_PAID_BASE_URL,
+  NANOGPT_PERSONALIZED_BASE_URL,
+  NANOGPT_SUBSCRIPTION_BASE_URL,
+  buildNanoGptModelDefinition,
+  type NanoGptCatalogSource,
+  type NanoGptModelEntry,
+  type NanoGptPluginConfig,
+  type NanoGptRoutingMode,
+} from "./models.js";
+
+const log = createSubsystemLogger("nanogpt-runtime");
+const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
+
+let cachedSubscription: { expiresAt: number; active: boolean } | null = null;
+
+function trimProvider(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function getNanoGptConfig(config: unknown): NanoGptPluginConfig {
+  if (!config || typeof config !== "object") {
+    return {};
+  }
+  const candidate = config as Record<string, unknown>;
+  return {
+    routingMode:
+      candidate.routingMode === "auto" ||
+      candidate.routingMode === "subscription" ||
+      candidate.routingMode === "paygo"
+        ? candidate.routingMode
+        : undefined,
+    catalogSource:
+      candidate.catalogSource === "auto" ||
+      candidate.catalogSource === "canonical" ||
+      candidate.catalogSource === "subscription" ||
+      candidate.catalogSource === "paid" ||
+      candidate.catalogSource === "personalized"
+        ? candidate.catalogSource
+        : undefined,
+    provider: typeof candidate.provider === "string" ? trimProvider(candidate.provider) : undefined,
+  };
+}
+
+export async function probeNanoGptSubscription(apiKey: string): Promise<boolean> {
+  const now = Date.now();
+  if (cachedSubscription && cachedSubscription.expiresAt > now) {
+    return cachedSubscription.active;
+  }
+
+  const response = await fetch(`${NANOGPT_SUBSCRIPTION_BASE_URL}/usage`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`NanoGPT subscription probe failed with HTTP ${response.status}`);
+  }
+
+  const data = (await response.json()) as { subscribed?: boolean; active?: boolean };
+  const active = Boolean(data.subscribed ?? data.active);
+  cachedSubscription = { active, expiresAt: now + SUBSCRIPTION_CACHE_TTL_MS };
+  return active;
+}
+
+export async function resolveNanoGptRoutingMode(params: {
+  config: NanoGptPluginConfig;
+  apiKey: string;
+}): Promise<Exclude<NanoGptRoutingMode, "auto">> {
+  const mode = params.config.routingMode ?? "auto";
+  if (mode === "subscription" || mode === "paygo") {
+    return mode;
+  }
+
+  try {
+    return (await probeNanoGptSubscription(params.apiKey)) ? "subscription" : "paygo";
+  } catch (error) {
+    log.warn(`Subscription probe failed: ${String(error)}`);
+    return "paygo";
+  }
+}
+
+export function resolveCatalogSource(params: {
+  config: NanoGptPluginConfig;
+  routingMode: "subscription" | "paygo";
+}): Exclude<NanoGptCatalogSource, "auto"> {
+  const source = params.config.catalogSource ?? "auto";
+  if (source !== "auto") {
+    return source;
+  }
+  return params.routingMode === "subscription" ? "subscription" : "canonical";
+}
+
+export function resolveCatalogBaseUrl(source: Exclude<NanoGptCatalogSource, "auto">): string {
+  switch (source) {
+    case "subscription":
+      return NANOGPT_SUBSCRIPTION_BASE_URL;
+    case "paid":
+      return NANOGPT_PAID_BASE_URL;
+    case "personalized":
+      return NANOGPT_PERSONALIZED_BASE_URL;
+    case "canonical":
+    default:
+      return NANOGPT_BASE_URL;
+  }
+}
+
+export function resolveRequestBaseUrl(routingMode: "subscription" | "paygo"): string {
+  return routingMode === "subscription" ? NANOGPT_SUBSCRIPTION_BASE_URL : NANOGPT_BASE_URL;
+}
+
+export async function discoverNanoGptModels(params: {
+  apiKey: string;
+  source: Exclude<NanoGptCatalogSource, "auto">;
+}): Promise<ModelDefinitionConfig[]> {
+  try {
+    const response = await fetch(`${resolveCatalogBaseUrl(params.source)}/models`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      log.warn(`NanoGPT model discovery failed with HTTP ${response.status}`);
+      return NANOGPT_FALLBACK_MODELS;
+    }
+
+    const data = (await response.json()) as { data?: NanoGptModelEntry[] } | NanoGptModelEntry[];
+    const entries = Array.isArray(data) ? data : Array.isArray(data.data) ? data.data : [];
+    const models = entries
+      .map((entry) => buildNanoGptModelDefinition(entry))
+      .filter((entry): entry is ModelDefinitionConfig => entry !== null);
+
+    return models.length > 0 ? models : NANOGPT_FALLBACK_MODELS;
+  } catch (error) {
+    log.warn(`NanoGPT model discovery failed: ${String(error)}`);
+    return NANOGPT_FALLBACK_MODELS;
+  }
+}
+
+export function buildNanoGptRequestHeaders(params: {
+  apiKey: string;
+  config: NanoGptPluginConfig;
+  routingMode: "subscription" | "paygo";
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${params.apiKey}`,
+  };
+
+  if (params.config.provider) {
+    headers["X-Provider"] = params.config.provider;
+    if (params.routingMode === "subscription") {
+      headers["X-Billing-Mode"] = "paygo";
+    }
+  }
+
+  return headers;
+}
+
+export function resetNanoGptRuntimeState(): void {
+  cachedSubscription = null;
+}
+```
+
+- [ ] **Step 11: Implement onboarding helpers**
+
+Create `onboard.ts`:
+
+```ts
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { NANOGPT_DEFAULT_MODEL_REF } from "./models.js";
+
+export function applyNanoGptProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[NANOGPT_DEFAULT_MODEL_REF] = {
+    ...models[NANOGPT_DEFAULT_MODEL_REF],
+    alias: models[NANOGPT_DEFAULT_MODEL_REF]?.alias ?? "NanoGPT",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyNanoGptConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyNanoGptProviderConfig(cfg), NANOGPT_DEFAULT_MODEL_REF);
+}
+```
+
+- [ ] **Step 12: Implement provider catalog builder**
+
+Create `provider-catalog.ts`:
+
+```ts
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  NANOGPT_PROVIDER_ID,
+  getNanoGptConfig,
+  resolveNanoGptRoutingMode,
+  resolveCatalogSource,
+  resolveRequestBaseUrl,
+  discoverNanoGptModels,
+} from "./runtime.js";
+
+export async function buildNanoGptProvider(params: {
+  apiKey: string;
+  pluginConfig: unknown;
+}): Promise<ModelProviderConfig> {
+  const config = getNanoGptConfig(params.pluginConfig);
+  const routingMode = await resolveNanoGptRoutingMode({
+    config,
+    apiKey: params.apiKey,
+  });
+  const source = resolveCatalogSource({ config, routingMode });
+  const models = await discoverNanoGptModels({
+    apiKey: params.apiKey,
+    source,
+  });
+
+  return {
+    baseUrl: resolveRequestBaseUrl(routingMode),
+    api: "openai-completions",
+    models: models.map((model) => ({
+      ...model,
+      provider: NANOGPT_PROVIDER_ID,
+      headers: undefined,
+    })),
+  };
+}
+```
+
+- [ ] **Step 13: Implement the plugin entrypoint**
+
+Create `index.ts`:
+
+```ts
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { applyNanoGptConfig } from "./onboard.js";
+import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
+import { buildNanoGptProvider } from "./provider-catalog.js";
+
+export default defineSingleProviderPluginEntry({
+  id: NANOGPT_PROVIDER_ID,
+  name: "NanoGPT Provider",
+  description: "NanoGPT provider plugin for OpenClaw",
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      routingMode: {
+        type: "string",
+        enum: ["auto", "subscription", "paygo"],
+      },
+      catalogSource: {
+        type: "string",
+        enum: ["auto", "canonical", "subscription", "paid", "personalized"],
+      },
+      provider: {
+        type: "string",
+      },
+    },
+  },
+  provider: {
+    label: "NanoGPT",
+    docsPath: "/providers/models",
+    envVars: ["NANOGPT_API_KEY"],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "NanoGPT API key",
+        hint: "Subscription or pay-as-you-go",
+        optionKey: "nanogptApiKey",
+        flagName: "--nanogpt-api-key",
+        envVar: "NANOGPT_API_KEY",
+        promptMessage: "Enter NanoGPT API key",
+        defaultModel: NANOGPT_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyNanoGptConfig(cfg),
+        wizard: {
+          choiceId: "nanogpt-api-key",
+          choiceLabel: "NanoGPT API key",
+          groupId: "nanogpt",
+          groupLabel: "NanoGPT",
+          groupHint: "Subscription or pay-as-you-go",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: () => {
+        throw new Error("buildProvider is not used directly for NanoGPT");
+      },
+    },
+    async catalog(ctx) {
+      const apiKey = ctx.resolveProviderApiKey(NANOGPT_PROVIDER_ID).apiKey;
+      if (!apiKey) {
+        return null;
+      }
+      return {
+        provider: await buildNanoGptProvider({
+          apiKey,
+          pluginConfig: ctx.pluginConfig,
+        }),
+      };
+    },
+  },
+});
+```
+
+- [ ] **Step 14: Fix the entrypoint to use `definePluginEntry` if the `catalog` override above does not type-check**
+
+If `defineSingleProviderPluginEntry` is too narrow for NanoGPT's async runtime-dependent catalog,
+replace `index.ts` with:
+
+```ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { applyNanoGptConfig } from "./onboard.js";
+import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
+import { buildNanoGptProvider } from "./provider-catalog.js";
+
+export default definePluginEntry({
+  id: NANOGPT_PROVIDER_ID,
+  name: "NanoGPT Provider",
+  description: "NanoGPT provider plugin for OpenClaw",
+  register(api) {
+    api.registerProvider({
+      id: NANOGPT_PROVIDER_ID,
+      label: "NanoGPT",
+      docsPath: "/providers/models",
+      envVars: ["NANOGPT_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: NANOGPT_PROVIDER_ID,
+          methodId: "api-key",
+          label: "NanoGPT API key",
+          hint: "Subscription or pay-as-you-go",
+          optionKey: "nanogptApiKey",
+          flagName: "--nanogpt-api-key",
+          envVar: "NANOGPT_API_KEY",
+          promptMessage: "Enter NanoGPT API key",
+          defaultModel: NANOGPT_DEFAULT_MODEL_REF,
+          expectedProviders: [NANOGPT_PROVIDER_ID],
+          applyConfig: (cfg) => applyNanoGptConfig(cfg),
+          wizard: {
+            choiceId: "nanogpt-api-key",
+            choiceLabel: "NanoGPT API key",
+            groupId: "nanogpt",
+            groupLabel: "NanoGPT",
+            groupHint: "Subscription or pay-as-you-go",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(NANOGPT_PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: await buildNanoGptProvider({
+              apiKey,
+              pluginConfig: ctx.pluginConfig,
+            }),
+          };
+        },
+      },
+    });
+  },
+});
+```
+
+- [ ] **Step 15: Create the local API barrel**
+
+Create `api.ts`:
+
+```ts
+export {
+  NANOGPT_BASE_URL,
+  NANOGPT_DEFAULT_MODEL_ID,
+  NANOGPT_DEFAULT_MODEL_REF,
+  NANOGPT_FALLBACK_MODELS,
+  NANOGPT_PAID_BASE_URL,
+  NANOGPT_PERSONALIZED_BASE_URL,
+  NANOGPT_PROVIDER_ID,
+  NANOGPT_SUBSCRIPTION_BASE_URL,
+  buildNanoGptModelDefinition,
+} from "./models.js";
+export { applyNanoGptConfig, applyNanoGptProviderConfig } from "./onboard.js";
+export { buildNanoGptProvider } from "./provider-catalog.js";
+export {
+  buildNanoGptRequestHeaders,
+  discoverNanoGptModels,
+  getNanoGptConfig,
+  probeNanoGptSubscription,
+  resetNanoGptRuntimeState,
+  resolveCatalogBaseUrl,
+  resolveCatalogSource,
+  resolveNanoGptRoutingMode,
+  resolveRequestBaseUrl,
+} from "./runtime.js";
+```
+
+- [ ] **Step 16: Run the tests to verify they now pass or fail for the right reasons**
+
+Run:
+
+```bash
+npm test -- index.test.ts runtime.test.ts
+```
+
+Expected:
+
+- Either PASS, or FAIL with specific assertion/type mismatches rather than missing files
+
+- [ ] **Step 17: Add deeper runtime behavior tests**
+
+Expand `runtime.test.ts` to cover:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildNanoGptRequestHeaders,
+  discoverNanoGptModels,
+  resetNanoGptRuntimeState,
+  resolveCatalogSource,
+  resolveNanoGptRoutingMode,
+} from "./runtime.js";
+
+afterEach(() => {
+  resetNanoGptRuntimeState();
+  vi.restoreAllMocks();
+});
+
+describe("runtime helpers", () => {
+  it("resolves auto to subscription when the probe says subscribed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ subscribed: true }),
+      })),
+    );
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "test-key",
+      }),
+    ).resolves.toBe("subscription");
+  });
+
+  it("falls back to paygo when the subscription probe fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 })));
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "test-key",
+      }),
+    ).resolves.toBe("paygo");
+  });
+
+  it("maps auto catalog source from routing mode", () => {
+    expect(resolveCatalogSource({ config: {}, routingMode: "subscription" })).toBe("subscription");
+    expect(resolveCatalogSource({ config: {}, routingMode: "paygo" })).toBe("canonical");
+  });
+
+  it("adds paygo billing override when provider selection is used on subscription routing", () => {
+    expect(
+      buildNanoGptRequestHeaders({
+        apiKey: "test-key",
+        config: { provider: "openrouter" },
+        routingMode: "subscription",
+      }),
+    ).toMatchObject({
+      Authorization: "Bearer test-key",
+      "X-Provider": "openrouter",
+      "X-Billing-Mode": "paygo",
+    });
+  });
+
+  it("falls back to static models when discovery fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 503 })));
+
+    const models = await discoverNanoGptModels({
+      apiKey: "test-key",
+      source: "canonical",
+    });
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models[0]?.id).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 18: Add provider catalog tests**
+
+Create `provider-catalog.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildNanoGptProvider } from "./provider-catalog.js";
+import { resetNanoGptRuntimeState } from "./runtime.js";
+
+afterEach(() => {
+  resetNanoGptRuntimeState();
+  vi.restoreAllMocks();
+});
+
+describe("buildNanoGptProvider", () => {
+  it("uses the subscription base URL when auto resolves to subscription", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ subscribed: true }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini", reasoning: true }],
+          }),
+        }),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: { routingMode: "auto", catalogSource: "auto" },
+    });
+
+    expect(provider.baseUrl).toContain("/api/subscription/v1");
+    expect(provider.models[0]?.id).toBe("gpt-5.4-mini");
+  });
+
+  it("uses the canonical base URL when paygo is pinned", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" }] }),
+      })),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: { routingMode: "paygo", catalogSource: "canonical" },
+    });
+
+    expect(provider.baseUrl).toContain("/api/v1");
+  });
+});
+```
+
+- [ ] **Step 19: Add or refine registration tests**
+
+Expand `index.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "openclaw/test/helpers/plugins/plugin-registration.js";
+import nanogptPlugin from "./index.js";
+
+describe("nanogpt provider registration", () => {
+  it("registers the nanogpt provider", async () => {
+    const provider = await registerSingleProviderPlugin(nanogptPlugin);
+
+    expect(provider.id).toBe("nanogpt");
+    expect(provider.label).toBe("NanoGPT");
+    expect(provider.docsPath).toBe("/providers/models");
+  });
+
+  it("registers API-key auth", async () => {
+    const provider = await registerSingleProviderPlugin(nanogptPlugin);
+
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.auth[0]?.id).toContain("api-key");
+  });
+});
+```
+
+- [ ] **Step 20: Run the focused test suite**
+
+Run:
+
+```bash
+npm test -- index.test.ts runtime.test.ts provider-catalog.test.ts
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 21: Run typechecking**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 22: Write the README**
+
+Create `README.md`:
+
+```md
+# NanoGPT Provider for OpenClaw
+
+NanoGPT provider plugin for OpenClaw with API-key auth, dynamic model discovery,
+and automatic subscription or pay-as-you-go routing.
+
+## Install
+
+```bash
+openclaw plugins install @deadronos/openclaw-nanogpt-provider
+```
+
+## Auth
+
+Set:
+
+```bash
+export NANOGPT_API_KEY=your_key_here
+```
+
+Or onboard with:
+
+```bash
+openclaw onboard --nanogpt-api-key your_key_here
+```
+
+## Config
+
+```json5
+{
+  plugins: {
+    entries: {
+      nanogpt: {
+        enabled: true,
+        config: {
+          routingMode: "auto",
+          catalogSource: "auto",
+          provider: "openrouter"
+        }
+      }
+    }
+  }
+}
+```
+
+## Options
+
+- `routingMode`: `auto`, `subscription`, `paygo`
+- `catalogSource`: `auto`, `canonical`, `subscription`, `paid`, `personalized`
+- `provider`: optional NanoGPT upstream provider id
+```
+
+- [ ] **Step 23: Run the full local verification pass**
+
+Run:
+
+```bash
+npm test
+npm run typecheck
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 24: Commit the implementation**
+
+Run:
+
+```bash
+git add package.json package-lock.json tsconfig.json openclaw.plugin.json index.ts api.ts models.ts runtime.ts provider-catalog.ts onboard.ts index.test.ts runtime.test.ts provider-catalog.test.ts README.md
+git commit -m "feat: add NanoGPT OpenClaw provider plugin"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - Provider registration: covered
+  - API-key auth: covered
+  - auto/subscription/paygo routing: covered
+  - catalog source switching: covered
+  - provider selection and billing override: covered
+  - fallback catalog behavior: covered
+  - docs and package metadata: covered
+- Placeholder scan:
+  - No `TODO`, `TBD`, or deferred implementation markers remain in the plan tasks
+- Type consistency:
+  - `routingMode`, `catalogSource`, `provider`, `NANOGPT_API_KEY`, and `nanogpt` are used consistently throughout
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-04-08-nanogpt-provider-plugin.md`.
+
+Two execution options:
+
+1. Subagent-Driven (recommended) - I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. Inline Execution - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("nanogpt plugin entry", () => {
+  it("exports the expected plugin metadata", () => {
+    expect(plugin.id).toBe("nanogpt");
+    expect(plugin.name).toBe("NanoGPT Provider");
+    expect(plugin.description).toContain("NanoGPT");
+    expect(typeof plugin.register).toBe("function");
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,60 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { applyNanoGptConfig } from "./onboard.js";
+import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
+import { buildNanoGptProvider } from "./provider-catalog.js";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: NANOGPT_PROVIDER_ID,
+  name: "NanoGPT Provider",
+  description: "NanoGPT provider plugin for OpenClaw",
+  register(api) {
+    const pluginConfig = api.pluginConfig;
+
+    api.registerProvider({
+      id: NANOGPT_PROVIDER_ID,
+      label: "NanoGPT",
+      docsPath: "/providers/models",
+      envVars: ["NANOGPT_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: NANOGPT_PROVIDER_ID,
+          methodId: "api-key",
+          label: "NanoGPT API key",
+          hint: "Subscription or pay-as-you-go",
+          optionKey: "nanogptApiKey",
+          flagName: "--nanogpt-api-key",
+          envVar: "NANOGPT_API_KEY",
+          promptMessage: "Enter NanoGPT API key",
+          defaultModel: NANOGPT_DEFAULT_MODEL_REF,
+          expectedProviders: [NANOGPT_PROVIDER_ID],
+          applyConfig: (cfg) => applyNanoGptConfig(cfg),
+          wizard: {
+            choiceId: "nanogpt-api-key",
+            choiceLabel: "NanoGPT API key",
+            groupId: "nanogpt",
+            groupLabel: "NanoGPT",
+            groupHint: "Subscription or pay-as-you-go",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx: ProviderCatalogContext) => {
+          const apiKey = ctx.resolveProviderApiKey(NANOGPT_PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+
+          return {
+            provider: await buildNanoGptProvider({
+              apiKey,
+              pluginConfig,
+            }),
+          };
+        },
+      },
+    });
+  },
+});

--- a/models.test.ts
+++ b/models.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  NANOGPT_DEFAULT_MODEL_REF,
+  NANOGPT_FALLBACK_MODELS,
+  buildNanoGptModelDefinition,
+} from "./models.js";
+
+describe("model constants", () => {
+  it("exposes the default NanoGPT model ref", () => {
+    expect(NANOGPT_DEFAULT_MODEL_REF).toBe("nanogpt/gpt-5.4-mini");
+  });
+
+  it("ships a non-empty fallback catalog", () => {
+    expect(NANOGPT_FALLBACK_MODELS.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildNanoGptModelDefinition", () => {
+  it("maps vision and pricing metadata into an OpenClaw model definition", () => {
+    expect(
+      buildNanoGptModelDefinition({
+        id: "gpt-5.4-mini",
+        displayName: "GPT-5.4 Mini",
+        reasoning: true,
+        vision: true,
+        contextWindow: 1234,
+        maxTokens: 567,
+        pricing: {
+          inputPer1kTokens: 0.1,
+          outputPer1kTokens: 0.2,
+        },
+      }),
+    ).toMatchObject({
+      id: "gpt-5.4-mini",
+      name: "GPT-5.4 Mini",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 1234,
+      maxTokens: 567,
+      cost: {
+        input: 100,
+        output: 200,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    });
+  });
+});

--- a/models.ts
+++ b/models.ts
@@ -1,0 +1,108 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const NANOGPT_PROVIDER_ID = "nanogpt";
+export const NANOGPT_BASE_URL = "https://nano-gpt.com/api/v1";
+export const NANOGPT_SUBSCRIPTION_BASE_URL = "https://nano-gpt.com/api/subscription/v1";
+export const NANOGPT_PAID_BASE_URL = "https://nano-gpt.com/api/paid/v1";
+export const NANOGPT_PERSONALIZED_BASE_URL = "https://nano-gpt.com/api/personalized/v1";
+export const NANOGPT_DEFAULT_MODEL_ID = "gpt-5.4-mini";
+export const NANOGPT_DEFAULT_MODEL_REF = `${NANOGPT_PROVIDER_ID}/${NANOGPT_DEFAULT_MODEL_ID}`;
+
+export type NanoGptRoutingMode = "auto" | "subscription" | "paygo";
+export type NanoGptCatalogSource =
+  | "auto"
+  | "canonical"
+  | "subscription"
+  | "paid"
+  | "personalized";
+
+export interface NanoGptPluginConfig {
+  routingMode?: NanoGptRoutingMode;
+  catalogSource?: NanoGptCatalogSource;
+  provider?: string;
+}
+
+export interface NanoGptModelEntry {
+  id?: string;
+  canonicalId?: string;
+  name?: string;
+  displayName?: string;
+  reasoning?: boolean;
+  vision?: boolean;
+  contextWindow?: number;
+  maxTokens?: number;
+  pricing?: {
+    inputPer1kTokens?: number;
+    outputPer1kTokens?: number;
+  };
+}
+
+export const NANOGPT_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+export const NANOGPT_FALLBACK_MODELS: ModelDefinitionConfig[] = [
+  {
+    id: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: NANOGPT_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 32768,
+  },
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: NANOGPT_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 32768,
+  },
+  {
+    id: "claude-sonnet-4.6",
+    name: "Claude Sonnet 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: NANOGPT_DEFAULT_COST,
+    contextWindow: 200000,
+    maxTokens: 32768,
+  },
+];
+
+function toPerMillion(value: number | undefined): number {
+  if (!Number.isFinite(value) || (value ?? 0) < 0) {
+    return 0;
+  }
+  return (value ?? 0) * 1000;
+}
+
+export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefinitionConfig | null {
+  const id = String(entry.canonicalId ?? entry.id ?? "").trim();
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    name: String(entry.displayName ?? entry.name ?? id),
+    reasoning: Boolean(entry.reasoning),
+    input: entry.vision ? ["text", "image"] : ["text"],
+    cost: {
+      input: toPerMillion(entry.pricing?.inputPer1kTokens),
+      output: toPerMillion(entry.pricing?.outputPer1kTokens),
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow:
+      typeof entry.contextWindow === "number" && entry.contextWindow > 0
+        ? entry.contextWindow
+        : 200000,
+    maxTokens:
+      typeof entry.maxTokens === "number" && entry.maxTokens > 0 ? entry.maxTokens : 32768,
+  };
+}

--- a/onboard.ts
+++ b/onboard.ts
@@ -1,0 +1,28 @@
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { NANOGPT_DEFAULT_MODEL_REF } from "./models.js";
+
+export function applyNanoGptProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[NANOGPT_DEFAULT_MODEL_REF] = {
+    ...models[NANOGPT_DEFAULT_MODEL_REF],
+    alias: models[NANOGPT_DEFAULT_MODEL_REF]?.alias ?? "NanoGPT",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyNanoGptConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyNanoGptProviderConfig(cfg), NANOGPT_DEFAULT_MODEL_REF);
+}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,55 @@
+{
+  "id": "nanogpt",
+  "name": "NanoGPT",
+  "description": "NanoGPT provider plugin for OpenClaw",
+  "providers": ["nanogpt"],
+  "providerAuthEnvVars": {
+    "nanogpt": ["NANOGPT_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "nanogpt",
+      "method": "api-key",
+      "choiceId": "nanogpt-api-key",
+      "choiceLabel": "NanoGPT API key",
+      "groupId": "nanogpt",
+      "groupLabel": "NanoGPT",
+      "groupHint": "Subscription or pay-as-you-go",
+      "optionKey": "nanogptApiKey",
+      "cliFlag": "--nanogpt-api-key",
+      "cliOption": "--nanogpt-api-key <key>",
+      "cliDescription": "NanoGPT API key"
+    }
+  ],
+  "uiHints": {
+    "routingMode": {
+      "label": "Routing Mode",
+      "help": "Choose auto, subscription, or paygo routing."
+    },
+    "catalogSource": {
+      "label": "Catalog Source",
+      "help": "Choose how NanoGPT model discovery should work."
+    },
+    "provider": {
+      "label": "Provider Override",
+      "help": "Optional NanoGPT upstream provider id for paygo provider selection."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "routingMode": {
+        "type": "string",
+        "enum": ["auto", "subscription", "paygo"]
+      },
+      "catalogSource": {
+        "type": "string",
+        "enum": ["auto", "canonical", "subscription", "paid", "personalized"]
+      },
+      "provider": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.6.0",
-        "openclaw": "file:../openclaw",
+        "openclaw": "^2026.4.5",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1767 @@
+{
+  "name": "@deadronos/openclaw-nanogpt-provider",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@deadronos/openclaw-nanogpt-provider",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.6.0",
+        "openclaw": "file:../openclaw",
+        "typescript": "^5.8.3",
+        "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.3.24-beta.2"
+      }
+    },
+    "../openclaw": {
+      "version": "2026.4.5",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.18.0",
+        "@anthropic-ai/vertex-sdk": "^0.14.4",
+        "@aws-sdk/client-bedrock": "3.1023.0",
+        "@aws-sdk/client-bedrock-runtime": "3.1023.0",
+        "@aws-sdk/credential-provider-node": "3.972.29",
+        "@clack/prompts": "^1.2.0",
+        "@homebridge/ciao": "^1.3.6",
+        "@line/bot-sdk": "^10.6.0",
+        "@lydell/node-pty": "1.2.0-beta.3",
+        "@mariozechner/pi-agent-core": "0.65.0",
+        "@mariozechner/pi-ai": "0.65.0",
+        "@mariozechner/pi-coding-agent": "0.65.0",
+        "@mariozechner/pi-tui": "0.65.0",
+        "@matrix-org/matrix-sdk-crypto-wasm": "18.0.0",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@mozilla/readability": "^0.6.0",
+        "@sinclair/typebox": "0.34.49",
+        "ajv": "^8.18.0",
+        "chalk": "^5.6.2",
+        "chokidar": "^5.0.0",
+        "cli-highlight": "^2.1.11",
+        "commander": "^14.0.3",
+        "croner": "^10.0.1",
+        "dotenv": "^17.4.0",
+        "express": "^5.2.1",
+        "file-type": "22.0.0",
+        "gaxios": "7.1.4",
+        "hono": "4.12.10",
+        "ipaddr.js": "^2.3.0",
+        "jiti": "^2.6.1",
+        "json5": "^2.2.3",
+        "jszip": "^3.10.1",
+        "linkedom": "^0.18.12",
+        "long": "^5.3.2",
+        "markdown-it": "^14.1.1",
+        "matrix-js-sdk": "41.3.0-rc.0",
+        "node-edge-tts": "^1.2.10",
+        "osc-progress": "^0.3.0",
+        "pdfjs-dist": "^5.6.205",
+        "playwright-core": "1.59.1",
+        "qrcode-terminal": "^0.12.0",
+        "sharp": "^0.34.5",
+        "sqlite-vec": "0.1.9",
+        "tar": "7.5.13",
+        "tslog": "^4.10.2",
+        "undici": "^8.0.1",
+        "uuid": "^13.0.0",
+        "ws": "^8.20.0",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "openclaw": "openclaw.mjs"
+      },
+      "devDependencies": {
+        "@grammyjs/types": "^3.25.0",
+        "@lit-labs/signals": "^0.2.0",
+        "@lit/context": "^1.1.6",
+        "@types/express": "^5.0.6",
+        "@types/markdown-it": "^14.1.2",
+        "@types/node": "^25.5.2",
+        "@types/qrcode-terminal": "^0.12.2",
+        "@types/ws": "^8.18.1",
+        "@typescript/native-preview": "7.0.0-dev.20260404.1",
+        "@vitest/coverage-v8": "^4.1.2",
+        "jscpd": "4.0.8",
+        "jsdom": "^29.0.1",
+        "lit": "^3.3.2",
+        "oxfmt": "0.43.0",
+        "oxlint": "^1.58.0",
+        "oxlint-tsgolint": "^0.19.0",
+        "semver": "7.7.4",
+        "signal-utils": "0.21.1",
+        "tsdown": "0.21.7",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=22.14.0"
+      },
+      "optionalDependencies": {
+        "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
+        "openshell": "0.1.0"
+      },
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.89",
+        "node-llama-cpp": "3.18.1"
+      },
+      "peerDependenciesMeta": {
+        "node-llama-cpp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/openclaw": {
+      "resolved": "../openclaw",
+      "link": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@deadronos/openclaw-nanogpt-provider",
+  "version": "0.1.0",
+  "description": "OpenClaw NanoGPT provider plugin",
+  "type": "module",
+  "license": "MIT",
+  "files": [
+    "index.ts",
+    "api.ts",
+    "models.ts",
+    "runtime.ts",
+    "provider-catalog.ts",
+    "onboard.ts",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.24-beta.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "openclaw": "file:../openclaw",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "providers": [
+      "nanogpt"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2",
+      "minGatewayVersion": "2026.3.24-beta.2"
+    },
+    "build": {
+      "openclawVersion": "2026.4.5",
+      "pluginSdkVersion": "2026.4.5"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,21 @@
   "version": "0.1.0",
   "description": "OpenClaw NanoGPT provider plugin",
   "type": "module",
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "provider",
+    "nanogpt",
+    "llm"
+  ],
+  "homepage": "https://github.com/deadronos/nanogpt-provider-openclaw#readme",
+  "bugs": {
+    "url": "https://github.com/deadronos/nanogpt-provider-openclaw/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deadronos/nanogpt-provider-openclaw.git"
+  },
   "license": "MIT",
   "files": [
     "index.ts",
@@ -12,7 +27,8 @@
     "provider-catalog.ts",
     "onboard.ts",
     "openclaw.plugin.json",
-    "README.md"
+    "README.md",
+    "LICENSE.md"
   ],
   "scripts": {
     "test": "vitest run",
@@ -27,6 +43,9 @@
     "openclaw": "^2026.4.5",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "openclaw": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
-    "openclaw": "file:../openclaw",
+    "openclaw": "^2026.4.5",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },

--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildNanoGptProvider } from "./provider-catalog.js";
+import { resetNanoGptRuntimeState } from "./runtime.js";
+
+afterEach(() => {
+  resetNanoGptRuntimeState();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("buildNanoGptProvider", () => {
+  it("uses the subscription base URL when auto resolves to subscription", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ subscribed: true }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini", reasoning: true }],
+          }),
+        }),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: { routingMode: "auto", catalogSource: "auto" },
+    });
+
+    expect(provider.baseUrl).toBe("https://nano-gpt.com/api/subscription/v1");
+    expect(provider.models[0]?.id).toBe("gpt-5.4-mini");
+  });
+
+  it("adds provider override headers and paygo billing override for subscription routing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" }] }),
+      })),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: {
+        routingMode: "subscription",
+        catalogSource: "subscription",
+        provider: "openrouter",
+      },
+    });
+
+    expect(provider.headers).toEqual({
+      Authorization: "Bearer test-key",
+      "X-Billing-Mode": "paygo",
+      "X-Provider": "openrouter",
+    });
+  });
+});

--- a/provider-catalog.ts
+++ b/provider-catalog.ts
@@ -1,0 +1,47 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  NANOGPT_PROVIDER_ID,
+  type NanoGptPluginConfig,
+} from "./models.js";
+import {
+  buildNanoGptRequestHeaders,
+  discoverNanoGptModels,
+  getNanoGptConfig,
+  resolveCatalogSource,
+  resolveNanoGptRoutingMode,
+  resolveRequestBaseUrl,
+} from "./runtime.js";
+
+export async function buildNanoGptProvider(params: {
+  apiKey: string;
+  pluginConfig?: unknown;
+}): Promise<ModelProviderConfig> {
+  const config: NanoGptPluginConfig = getNanoGptConfig(params.pluginConfig);
+  const routingMode = await resolveNanoGptRoutingMode({
+    config,
+    apiKey: params.apiKey,
+  });
+  const catalogSource = resolveCatalogSource({
+    config,
+    routingMode,
+  });
+  const models = await discoverNanoGptModels({
+    apiKey: params.apiKey,
+    source: catalogSource,
+  });
+
+  return {
+    baseUrl: resolveRequestBaseUrl(routingMode),
+    api: "openai-completions",
+    apiKey: params.apiKey,
+    headers: buildNanoGptRequestHeaders({
+      apiKey: params.apiKey,
+      config,
+      routingMode,
+    }),
+    models: models.map((model) => ({
+      ...model,
+      provider: NANOGPT_PROVIDER_ID,
+    })),
+  };
+}

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildNanoGptRequestHeaders,
+  getNanoGptConfig,
+  resetNanoGptRuntimeState,
+  resolveCatalogSource,
+  resolveNanoGptRoutingMode,
+} from "./runtime.js";
+
+afterEach(() => {
+  resetNanoGptRuntimeState();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("getNanoGptConfig", () => {
+  it("normalizes supported config fields", () => {
+    expect(
+      getNanoGptConfig({
+        routingMode: "subscription",
+        catalogSource: "personalized",
+        provider: " openrouter ",
+      }),
+    ).toEqual({
+      routingMode: "subscription",
+      catalogSource: "personalized",
+      provider: "openrouter",
+    });
+  });
+});
+
+describe("resolveNanoGptRoutingMode", () => {
+  it("returns explicit paygo without probing", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "paygo" },
+        apiKey: "test-key",
+      }),
+    ).resolves.toBe("paygo");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveCatalogSource", () => {
+  it("maps auto to subscription when routing resolved to subscription", () => {
+    expect(resolveCatalogSource({ config: {}, routingMode: "subscription" })).toBe("subscription");
+  });
+});
+
+describe("buildNanoGptRequestHeaders", () => {
+  it("adds provider override and billing override for subscription routing", () => {
+    expect(
+      buildNanoGptRequestHeaders({
+        apiKey: "test-key",
+        config: { provider: "openrouter" },
+        routingMode: "subscription",
+      }),
+    ).toEqual({
+      Authorization: "Bearer test-key",
+      "X-Billing-Mode": "paygo",
+      "X-Provider": "openrouter",
+    });
+  });
+});

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -43,6 +43,41 @@ describe("resolveNanoGptRoutingMode", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it("caches subscription status per api key", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ subscribed: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ subscribed: false }),
+      });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "key-a",
+      }),
+    ).resolves.toBe("subscription");
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "key-a",
+      }),
+    ).resolves.toBe("subscription");
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "key-b",
+      }),
+    ).resolves.toBe("paygo");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("resolveCatalogSource", () => {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,0 +1,168 @@
+import {
+  NANOGPT_BASE_URL,
+  NANOGPT_FALLBACK_MODELS,
+  NANOGPT_PERSONALIZED_BASE_URL,
+  NANOGPT_PAID_BASE_URL,
+  NANOGPT_SUBSCRIPTION_BASE_URL,
+  buildNanoGptModelDefinition,
+  type NanoGptCatalogSource,
+  type NanoGptModelEntry,
+  type NanoGptPluginConfig,
+  type NanoGptRoutingMode,
+} from "./models.js";
+
+const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
+
+let subscriptionCache: { active: boolean; expiresAt: number } | null = null;
+
+export function getNanoGptConfig(config: unknown): NanoGptPluginConfig {
+  if (!config || typeof config !== "object") {
+    return {};
+  }
+
+  const candidate = config as Record<string, unknown>;
+  const provider =
+    typeof candidate.provider === "string" && candidate.provider.trim()
+      ? candidate.provider.trim()
+      : undefined;
+
+  return {
+    routingMode:
+      candidate.routingMode === "auto" ||
+      candidate.routingMode === "subscription" ||
+      candidate.routingMode === "paygo"
+        ? candidate.routingMode
+        : undefined,
+    catalogSource:
+      candidate.catalogSource === "auto" ||
+      candidate.catalogSource === "canonical" ||
+      candidate.catalogSource === "subscription" ||
+      candidate.catalogSource === "paid" ||
+      candidate.catalogSource === "personalized"
+        ? candidate.catalogSource
+        : undefined,
+    ...(provider ? { provider } : {}),
+  };
+}
+
+export async function probeNanoGptSubscription(apiKey: string): Promise<boolean> {
+  const now = Date.now();
+  if (subscriptionCache && subscriptionCache.expiresAt > now) {
+    return subscriptionCache.active;
+  }
+
+  const response = await fetch(`${NANOGPT_SUBSCRIPTION_BASE_URL}/usage`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`NanoGPT subscription probe failed with HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as { subscribed?: boolean; active?: boolean };
+  const active = Boolean(payload.subscribed ?? payload.active);
+  subscriptionCache = { active, expiresAt: now + SUBSCRIPTION_CACHE_TTL_MS };
+  return active;
+}
+
+export async function resolveNanoGptRoutingMode(params: {
+  config: NanoGptPluginConfig;
+  apiKey: string;
+}): Promise<Exclude<NanoGptRoutingMode, "auto">> {
+  const routingMode = params.config.routingMode ?? "auto";
+  if (routingMode === "paygo" || routingMode === "subscription") {
+    return routingMode;
+  }
+
+  try {
+    return (await probeNanoGptSubscription(params.apiKey)) ? "subscription" : "paygo";
+  } catch {
+    return "paygo";
+  }
+}
+
+export function resolveCatalogSource(params: {
+  config: NanoGptPluginConfig;
+  routingMode: Exclude<NanoGptRoutingMode, "auto">;
+}): Exclude<NanoGptCatalogSource, "auto"> {
+  const catalogSource = params.config.catalogSource ?? "auto";
+  if (catalogSource !== "auto") {
+    return catalogSource;
+  }
+
+  return params.routingMode === "subscription" ? "subscription" : "canonical";
+}
+
+export function resolveCatalogBaseUrl(source: Exclude<NanoGptCatalogSource, "auto">): string {
+  switch (source) {
+    case "subscription":
+      return NANOGPT_SUBSCRIPTION_BASE_URL;
+    case "paid":
+      return NANOGPT_PAID_BASE_URL;
+    case "personalized":
+      return NANOGPT_PERSONALIZED_BASE_URL;
+    case "canonical":
+    default:
+      return NANOGPT_BASE_URL;
+  }
+}
+
+export function resolveRequestBaseUrl(routingMode: Exclude<NanoGptRoutingMode, "auto">): string {
+  return routingMode === "subscription" ? NANOGPT_SUBSCRIPTION_BASE_URL : NANOGPT_BASE_URL;
+}
+
+export async function discoverNanoGptModels(params: {
+  apiKey: string;
+  source: Exclude<NanoGptCatalogSource, "auto">;
+}) {
+  try {
+    const response = await fetch(`${resolveCatalogBaseUrl(params.source)}/models`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+    });
+    if (!response.ok) {
+      return NANOGPT_FALLBACK_MODELS;
+    }
+
+    const payload = (await response.json()) as { data?: NanoGptModelEntry[] } | NanoGptModelEntry[];
+    const entries = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload.data)
+        ? payload.data
+        : [];
+    const models = entries
+      .map((entry) => buildNanoGptModelDefinition(entry))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    return models.length > 0 ? models : NANOGPT_FALLBACK_MODELS;
+  } catch {
+    return NANOGPT_FALLBACK_MODELS;
+  }
+}
+
+export function buildNanoGptRequestHeaders(params: {
+  apiKey: string;
+  config: NanoGptPluginConfig;
+  routingMode: Exclude<NanoGptRoutingMode, "auto">;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${params.apiKey}`,
+  };
+
+  if (params.config.provider) {
+    headers["X-Provider"] = params.config.provider;
+    if (params.routingMode === "subscription") {
+      headers["X-Billing-Mode"] = "paygo";
+    }
+  }
+
+  return headers;
+}
+
+export function resetNanoGptRuntimeState(): void {
+  subscriptionCache = null;
+}

--- a/runtime.ts
+++ b/runtime.ts
@@ -13,7 +13,7 @@ import {
 
 const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
 
-let subscriptionCache: { active: boolean; expiresAt: number } | null = null;
+const subscriptionCache = new Map<string, { active: boolean; expiresAt: number }>();
 
 export function getNanoGptConfig(config: unknown): NanoGptPluginConfig {
   if (!config || typeof config !== "object") {
@@ -47,8 +47,9 @@ export function getNanoGptConfig(config: unknown): NanoGptPluginConfig {
 
 export async function probeNanoGptSubscription(apiKey: string): Promise<boolean> {
   const now = Date.now();
-  if (subscriptionCache && subscriptionCache.expiresAt > now) {
-    return subscriptionCache.active;
+  const cached = subscriptionCache.get(apiKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.active;
   }
 
   const response = await fetch(`${NANOGPT_SUBSCRIPTION_BASE_URL}/usage`, {
@@ -64,7 +65,7 @@ export async function probeNanoGptSubscription(apiKey: string): Promise<boolean>
 
   const payload = (await response.json()) as { subscribed?: boolean; active?: boolean };
   const active = Boolean(payload.subscribed ?? payload.active);
-  subscriptionCache = { active, expiresAt: now + SUBSCRIPTION_CACHE_TTL_MS };
+  subscriptionCache.set(apiKey, { active, expiresAt: now + SUBSCRIPTION_CACHE_TTL_MS });
   return active;
 }
 
@@ -164,5 +165,5 @@ export function buildNanoGptRequestHeaders(params: {
 }
 
 export function resetNanoGptRuntimeState(): void {
-  subscriptionCache = null;
+  subscriptionCache.clear();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
- add an external OpenClaw NanoGPT provider plugin with API-key auth and plugin manifest metadata
- implement NanoGPT routing helpers for auto subscription detection, catalog source selection, provider overrides, and fallback model discovery
- add focused tests plus README/setup guidance for local development and installation

## Test Plan
- [x] npm test
- [x] npm run typecheck
