### PR TITLE
Align NanoGPT pricing with provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,102 @@
 # NanoGPT Provider for OpenClaw
 
-Unofficial NanoGPT provider plugin for OpenClaw with API-key auth, dynamic model
-discovery, automatic subscription or pay-as-you-go routing, opt-in Responses API
-support, NanoGPT-backed web search, and native image generation.
+Unofficial NanoGPT provider plugin for OpenClaw.
+It adds:
 
-## Current Surface
-
-Implemented today:
-
-- Text model catalog + inference transport via NanoGPT
-- Automatic subscription vs pay-as-you-go request routing for text models
-- Opt-in OpenAI Responses transport for text models
+- NanoGPT text model discovery and inference
+- automatic subscription vs pay-as-you-go routing for text models
+- optional OpenAI Responses transport
 - NanoGPT-backed `web_search`
 - NanoGPT-backed image generation and image editing
+- NanoGPT subscription usage snapshots via OpenClaw's provider-usage surface
 
-Not implemented today:
+## What works today
 
-- Subscription quota tracking inside the plugin
-- Exhaustive NanoGPT image-model discovery from an official image-model catalog
-- Full NanoGPT usage accounting for the included daily and weekly limits
+- text model catalog + inference transport via NanoGPT
+- automatic subscription vs pay-as-you-go request routing for text models
+- opt-in OpenAI Responses transport for text models
+- NanoGPT-backed `web_search`
+- NanoGPT-backed image generation and image editing
+- daily/monthly NanoGPT subscription quota snapshots exposed to OpenClaw
 
-## Screenshot
+## Current limitations
 
-![image](image.png)
+- no exhaustive official NanoGPT image-model discovery yet
+- no authoritative weekly token accounting from the documented NanoGPT API
+- pricing is aligned for a configured upstream provider only when NanoGPT
+  exposes provider-selection pricing for that model
 
-## Install from npm (not implemented yet, see "Future improvements" below)
+NanoGPT's documented usage endpoint reports quota windows, not true token
+usage. The plugin exposes those daily/monthly quota snapshots to OpenClaw, but
+it does not reconstruct token counts from them.
 
-```bash
-openclaw plugins install @deadronos/nanogpt-provider-openclaw
-```
+## Screenshots
 
-## Install locally without publishing (preferred for now)
+![NanoGPT provider screenshot](image.png)
 
-Install directly from the repo checkout:
+## Install
+
+### Local install from a checkout
+
+This is the most practical path right now.
 
 ```bash
 cd ~/Github
-git clone @deadronos/nanogpt-provider-openclaw
-
+git clone git@github.com:deadronos/nanogpt-provider-openclaw.git
 openclaw plugins install ~/Github/nanogpt-provider-openclaw
+openclaw gateway restart
 ```
 
-Or build a tarball and install that exact package artifact:
+### Install from a tarball
 
 ```bash
 npm pack
 openclaw plugins install ./deadronos-openclaw-nanogpt-provider-0.1.0.tgz
-```
-
-Restart the gateway after install:
-
-```bash
 openclaw gateway restart
 ```
 
-## Auth
+### npm install
 
-Set:
+The README previously mentioned direct npm installation, but that publish flow is
+not the primary path yet. If you do publish, the release commands are listed in
+the development section below.
+
+## Authentication and setup
+
+Set a NanoGPT API key:
 
 ```bash
 export NANOGPT_API_KEY=your_key_here
 ```
 
-## New openclaw configs
-
-Onboard with:
+You can then onboard directly:
 
 ```bash
 openclaw onboard --nanogpt-api-key your_key_here
 ```
 
-## Add to existing config
+Or add it to an existing OpenClaw setup:
 
 ```bash
 openclaw configure
-
-Select Models and "NanoGPT" as provider, it will prompt for API key, then autodiscover catalog and display available NanoGPT text models for selection.
 ```
 
-This one key is used for:
+Choose **Models** and then **NanoGPT** as the provider. OpenClaw will prompt
+for the API key, autodiscover the NanoGPT catalog, and let you select from the
+available text models.
+
+The same key is used for:
 
 - text model access
 - NanoGPT web search
 - NanoGPT image generation
 
-The plugin reads `NANOGPT_API_KEY` by default. Web search can also store its
-credential in a dedicated config path described below.
+The plugin reads `NANOGPT_API_KEY` by default. Web search can also use a
+dedicated config credential path described below.
 
-## Provider Config
+## Text provider configuration
 
-The provider plugin config controls NanoGPT text-model discovery and transport:
+The plugin config controls NanoGPT text-model discovery and transport behavior:
 
 ```json5
 {
@@ -109,14 +116,14 @@ The provider plugin config controls NanoGPT text-model discovery and transport:
 }
 ```
 
-## Provider Options
+### Options
 
 - `routingMode`: `auto`, `subscription`, `paygo`
 - `catalogSource`: `auto`, `canonical`, `subscription`, `paid`, `personalized`
 - `requestApi`: `auto`, `completions`, `responses`
 - `provider`: optional NanoGPT upstream provider id
 
-Behavior notes:
+### Behavior notes
 
 - `routingMode: "auto"` probes NanoGPT subscription status and falls back to
   `paygo` if the probe fails.
@@ -124,47 +131,57 @@ Behavior notes:
   routed through subscription mode, otherwise `canonical`.
 - `requestApi: "responses"` switches text inference to OpenAI Responses
   transport. `auto` currently behaves the same as `completions`.
-- `provider` adds NanoGPT's `X-Provider` override header for text requests. If
-  you force an upstream provider while text routing is in subscription mode, the
-  plugin also sets `X-Billing-Mode: paygo`.
-- when `provider` is set, the plugin also tries to align exposed model pricing
-  with NanoGPT's provider-selection pricing endpoint so `models[].cost` better
-  reflects the selected upstream provider's billed price.
+- `provider` adds NanoGPT's `X-Provider` override header for text requests.
+- if `provider` is set while the request would otherwise use subscription
+  routing, the plugin also sets `X-Billing-Mode: paygo`
 
-## Web Search
+### Pricing behavior
 
-The plugin now also registers a NanoGPT-backed `web_search` provider using
-NanoGPT's direct `POST /api/web` endpoint.
+By default, the plugin exposes pricing from NanoGPT's detailed model catalog.
 
-Web search details:
+When `provider` is set, the plugin also tries to align exposed `models[].cost`
+with NanoGPT's provider-selection pricing endpoint so the model cost shown to
+OpenClaw better reflects the billed price for the selected upstream provider.
+
+If NanoGPT does not expose provider-selection pricing for a model, the plugin
+falls back to the default catalog pricing instead of failing model discovery.
+
+## Web search
+
+The plugin registers a NanoGPT-backed `web_search` provider using NanoGPT's
+direct `POST /api/web` endpoint.
+
+### Current search behavior
 
 - endpoint: `POST https://nano-gpt.com/api/web`
-- fixed upstream settings: `provider: "linkup"`, `depth: "standard"`,
-  `outputType: "searchResults"`
+- fixed upstream settings:
+  - `provider: "linkup"`
+  - `depth: "standard"`
+  - `outputType: "searchResults"`
 - supported tool parameters:
   - `query` required
   - `count` optional, clamped to `1-10`
   - `includeDomains` optional
   - `excludeDomains` optional
 
-Credential sources, in resolution order:
+### Credential resolution
+
+Web search resolves credentials in this order:
 
 - `plugins.entries.nanogpt.config.webSearch.apiKey`
 - `NANOGPT_API_KEY`
 
-Note:
+`plugins.entries.nanogpt.config.webSearch.apiKey` is the web-search provider's
+credential storage path, not part of the top-level NanoGPT text-provider config
+schema shown above.
 
-- `plugins.entries.nanogpt.config.webSearch.apiKey` is the web-search provider's
-  credential storage path, not part of the top-level NanoGPT text-provider
-  config schema shown above.
+## Image generation
 
-## Image Generation
-
-The plugin now also registers a NanoGPT image generation provider backed by:
+The plugin registers a NanoGPT image generation provider backed by:
 
 - `POST https://nano-gpt.com/v1/images/generations`
 
-Current curated image model list:
+### Current curated image models
 
 - `hidream`
 - `chroma`
@@ -173,49 +190,59 @@ Current curated image model list:
 
 The default image model is `hidream`.
 
-Current image capabilities:
+### Current image capabilities
 
-- generation and edit flows are both enabled
+- generation and edit flows are enabled
 - `count` up to `4`
 - up to `4` input images for edit flows
 - supported sizes: `256x256`, `512x512`, `1024x1024`
 - response handling expects `b64_json`
 
-The provider also normalizes friendly subscription labels to the curated NanoGPT
-ids above. For example:
+### Model aliases
+
+The provider normalizes friendly subscription labels to curated NanoGPT ids. For
+example:
 
 - `HIDREAM` -> `hidream`
 - `CHROMA` -> `chroma`
 - `Z IMAGE TURBO` -> `z-image-turbo`
 - `QWEN IMAGE` -> `qwen-image-2512`
 
-If NanoGPT rejects an image model id, the provider now returns an error that
-points back to the curated model list and these accepted aliases.
+If NanoGPT rejects an image model id, the provider returns an error that points
+back to the curated model list and these accepted aliases.
 
-Model-id note:
+### Notes on current mappings
 
-- `hidream` and `chroma` are straightforward mappings.
-- `z-image-turbo` and `qwen-image-2512` are the best current API-id mappings for
-  the subscription-included labels "Z IMAGE TURBO" and "QWEN IMAGE" based on
-  NanoGPT's public surfaces.
+- `hidream` and `chroma` are straightforward mappings
+- `z-image-turbo` and `qwen-image-2512` are the best current API-id mappings
+  for the subscription-included labels `Z IMAGE TURBO` and `QWEN IMAGE` based
+  on NanoGPT's public surfaces
 
-## Limitations
+## Usage reporting
 
-NanoGPT's documented usage endpoint reports quota windows, not true token
-usage. The plugin exposes those daily/monthly quota snapshots to OpenClaw, but
-it does not reconstruct token counts from them.
+The plugin implements NanoGPT usage reporting through OpenClaw's supported
+provider-usage hooks.
 
-The plugin currently does not maintain a local, authoritative counter for:
+Today that means:
 
-- weekly subscription text-token allowances
-- daily included image generations
+- subscription active/inactive state
+- daily quota window percentage + reset time
+- monthly quota window percentage + reset time
 
-For text routing, the plugin only probes whether subscription mode appears
-active. It does not currently reconcile or enforce NanoGPT usage quotas.
+It does **not** currently provide authoritative token accounting for NanoGPT's
+weekly token allowances because the documented NanoGPT usage payload does not
+expose that data directly.
 
-## Future improvements in this area could include
+## Development
 
-## Publish to npm
+### Verify locally
+
+```bash
+npm test
+npm run typecheck
+```
+
+### Publish workflow
 
 ```bash
 npm test
@@ -224,6 +251,14 @@ npm pack --dry-run
 npm publish --access public
 ```
 
-## Token usage accounting
+## Future improvements
 
-![image](image_token_counting.png)
+- official image-model discovery if NanoGPT documents a stable catalog surface
+- richer pricing and provider-selection UX if OpenClaw adds broader pricing
+  display surfaces
+- better token-usage accounting if NanoGPT exposes authoritative weekly token
+  telemetry
+
+## Token usage accounting notes
+
+![Token usage accounting sketch](image_token_counting.png)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Not implemented today:
 
 ![image](image.png)
 
-
 ## Install from npm (not implemented yet, see "Future improvements" below)
 
 ```bash
@@ -38,7 +37,6 @@ Install directly from the repo checkout:
 ```bash
 cd ~/Github
 git clone @deadronos/nanogpt-provider-openclaw
-
 
 openclaw plugins install ~/Github/nanogpt-provider-openclaw
 ```
@@ -64,20 +62,21 @@ Set:
 export NANOGPT_API_KEY=your_key_here
 ```
 
-## New openclaw configs:
+## New openclaw configs
+
 Onboard with:
 
 ```bash
 openclaw onboard --nanogpt-api-key your_key_here
 ```
-## Add to existing config:
+
+## Add to existing config
 
 ```bash
 openclaw configure
 
 Select Models and "NanoGPT" as provider, it will prompt for API key, then autodiscover catalog and display available NanoGPT text models for selection.
 ```
-
 
 This one key is used for:
 
@@ -128,6 +127,9 @@ Behavior notes:
 - `provider` adds NanoGPT's `X-Provider` override header for text requests. If
   you force an upstream provider while text routing is in subscription mode, the
   plugin also sets `X-Billing-Mode: paygo`.
+- when `provider` is set, the plugin also tries to align exposed model pricing
+  with NanoGPT's provider-selection pricing endpoint so `models[].cost` better
+  reflects the selected upstream provider's billed price.
 
 ## Web Search
 
@@ -211,8 +213,7 @@ The plugin currently does not maintain a local, authoritative counter for:
 For text routing, the plugin only probes whether subscription mode appears
 active. It does not currently reconcile or enforce NanoGPT usage quotas.
 
-
-## Future improvements in this area could include:
+## Future improvements in this area could include
 
 ## Publish to npm
 
@@ -222,7 +223,6 @@ npm run typecheck
 npm pack --dry-run
 npm publish --access public
 ```
-
 
 ## Token usage accounting
 

--- a/docs/superpowers/specs/2026-04-10-nanogpt-provider-selection-pricing.md
+++ b/docs/superpowers/specs/2026-04-10-nanogpt-provider-selection-pricing.md
@@ -1,0 +1,192 @@
+# NanoGPT Provider-Selection Pricing Alignment
+
+## Summary
+
+The NanoGPT plugin already maps default model pricing from
+`GET /api/v1/models?detailed=true` into OpenClaw's supported
+`ModelDefinitionConfig.cost` surface. That is correct for default NanoGPT
+routing, but it becomes inaccurate when the plugin is configured with a fixed
+upstream provider override via `X-Provider`.
+
+NanoGPT documents a second pricing surface for provider-selectable models:
+
+- `GET /api/models/:canonicalId/providers`
+
+That endpoint returns the default price plus provider-specific prices, including
+the markup that applies when a provider is explicitly selected.
+
+This spec aligns the plugin's exposed model pricing with the actual billing mode
+used by the plugin when `plugins.entries.nanogpt.config.provider` is set.
+
+## Current State
+
+- `runtime.ts` discovers text models from NanoGPT model list endpoints with
+  `?detailed=true`.
+- `models.ts` maps `pricing.prompt` and `pricing.completion` into
+  `ModelDefinitionConfig.cost.input` and `.output`.
+- `provider-catalog.ts` returns those model definitions through OpenClaw's
+  supported provider catalog surface.
+- When `pluginConfig.provider` is set, the plugin sends `X-Provider` for text
+  requests and sends `X-Billing-Mode: paygo` for subscription routing.
+
+This means the plugin may expose one price in the model catalog while NanoGPT
+bills a different provider-selected price at request time.
+
+## Goal
+
+When a NanoGPT upstream provider override is configured, update the catalog's
+`models[].cost` values to match NanoGPT's documented provider-specific pricing
+for the selected upstream provider whenever NanoGPT exposes that information.
+
+## Non-Goals
+
+- No OpenClaw core changes.
+- No new pricing fields beyond the existing `cost` surface.
+- No attempt to surface all provider options inside OpenClaw model pickers.
+- No change to request routing behavior.
+
+## Target Behavior
+
+### Default routing
+
+If no NanoGPT upstream provider override is configured:
+
+- continue using `GET /models?detailed=true`
+- continue exposing default NanoGPT pricing from the model list payload
+
+### Provider-selected routing
+
+If `pluginConfig.provider` is configured:
+
+1. Discover the normal model catalog from NanoGPT as today.
+2. For each discovered model, query NanoGPT's provider-selection endpoint:
+   - `GET /api/models/:canonicalId/providers`
+3. If NanoGPT reports pricing for the configured provider and the provider is
+   available for that model, replace the model's exposed `cost.input` and
+   `cost.output` with the provider-specific pricing.
+4. If the endpoint fails, the model does not support provider selection, or the
+   configured provider is not present for that model, keep the default model
+   price from `/models?detailed=true`.
+
+## API Contracts
+
+### Existing catalog source
+
+`GET /api/v1/models?detailed=true`
+
+Relevant fields already consumed:
+
+- `id`
+- `canonicalId` when present
+- `name` / `displayName`
+- `context_length`
+- `max_output_tokens`
+- `capabilities`
+- `pricing.prompt`
+- `pricing.completion`
+- `pricing.unit`
+
+### New provider-pricing source
+
+`GET /api/models/:canonicalId/providers`
+
+Expected relevant fields based on NanoGPT docs:
+
+- `supportsProviderSelection`
+- `defaultPrice`
+- `providers[].provider`
+- `providers[].available`
+- `providers[].pricing.inputPer1kTokens`
+- `providers[].pricing.outputPer1kTokens`
+
+The docs describe provider-selection pricing in per-1k-token units, so the
+plugin must convert those values to OpenClaw's existing per-million-token
+`cost` contract.
+
+## Implementation Plan
+
+### Types
+
+Add provider-selection payload types next to the existing model/pricing types.
+
+### Runtime
+
+Add a provider-pricing enrichment pass in `runtime.ts` that:
+
+- runs only when `config.provider` is set
+- fetches NanoGPT provider pricing for each discovered model id
+- applies provider-specific pricing only when NanoGPT returns a usable match
+- falls back cleanly to the default catalog price on any error or unsupported
+  model
+
+To avoid a slow catalog build from purely serial fetches, apply the enrichment
+in bounded concurrent batches.
+
+### Model mapping
+
+Add a helper in `models.ts` that merges provider-specific pricing into an
+existing `ModelDefinitionConfig` without changing unrelated metadata.
+
+### Provider catalog
+
+Pass the configured provider id from `provider-catalog.ts` into model discovery
+so the runtime can enrich pricing before returning the model list.
+
+### Tests
+
+Add coverage for:
+
+- merging provider pricing into an existing model definition
+- converting provider-pricing per-1k values into per-million `cost`
+- keeping default prices when provider selection is unsupported or unavailable
+- propagating provider-specific prices through `buildNanoGptProvider(...)`
+
+## Failure Handling
+
+If the provider-pricing endpoint fails for one or more models:
+
+- do not fail the whole provider catalog build
+- keep the default model prices from `/models?detailed=true`
+
+This preserves current plugin behavior and avoids turning a pricing-enrichment
+feature into a catalog-availability regression.
+
+## Risks
+
+- NanoGPT's provider-pricing endpoint is a second network fan-out and may add
+  latency when a provider override is configured.
+- Some models may omit provider-selection data or use evolving field shapes.
+- A configured provider can be valid globally but unavailable for a specific
+  model.
+
+## Mitigations
+
+- only enable the enrichment path when `pluginConfig.provider` is present
+- keep conservative fallbacks to the existing default model pricing
+- batch requests with bounded concurrency instead of unbounded parallel fan-out
+- match provider ids case-insensitively
+
+## Verification
+
+### Automated
+
+- targeted Vitest coverage for model pricing enrichment and provider catalog
+  construction
+- full `npm test`
+- `npm run typecheck`
+
+### Live
+
+With a valid NanoGPT API key:
+
+1. fetch one detailed models payload
+2. fetch one provider-pricing payload for a provider-selectable model
+3. confirm the plugin's mapped `cost` reflects provider pricing when
+   `pluginConfig.provider` matches the returned provider id
+
+## Expected Outcome
+
+After this change, the plugin will continue to expose pricing to OpenClaw
+through the existing supported `models[].cost` surface, but those values will
+more accurately reflect actual NanoGPT billing whenever the plugin forces a
+specific upstream provider.

--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -157,9 +157,7 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
             return null;
           }
           return {
-            buffer: typeof Buffer !== "undefined"
-              ? Buffer.from(entry.b64_json, "base64")
-              : Uint8Array.from(atob(entry.b64_json), (c) => c.charCodeAt(0)),
+            buffer: Buffer.from(entry.b64_json, "base64"),
             mimeType: NANOGPT_DEFAULT_OUTPUT_MIME,
             fileName: `image-${index + 1}.${inferFileExtensionFromMimeType(
               NANOGPT_DEFAULT_OUTPUT_MIME,

--- a/models.test.ts
+++ b/models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   NANOGPT_DEFAULT_MODEL_REF,
   NANOGPT_FALLBACK_MODELS,
+  applyNanoGptProviderPricing,
   buildNanoGptModelDefinition,
 } from "./models.js";
 
@@ -59,5 +60,28 @@ describe("buildNanoGptModelDefinition", () => {
       id: "legacy-vision-model",
       input: ["text", "image"],
     });
+  });
+
+  it("overrides model cost with provider-specific per-1k pricing when available", () => {
+    const model = buildNanoGptModelDefinition({
+      id: "provider-priced-model",
+      pricing: {
+        prompt: 2.5,
+        completion: 10,
+        unit: "per_million_tokens",
+      },
+    });
+
+    expect(model).not.toBeNull();
+    const priced = applyNanoGptProviderPricing(model!, {
+      inputPer1kTokens: 0.00042,
+      outputPer1kTokens: 0.0018375,
+      unit: "per_1k_tokens",
+    });
+
+    expect(priced.cost.input).toBeCloseTo(0.42, 10);
+    expect(priced.cost.output).toBeCloseTo(1.8375, 10);
+    expect(priced.cost.cacheRead).toBe(0);
+    expect(priced.cost.cacheWrite).toBe(0);
   });
 });

--- a/models.ts
+++ b/models.ts
@@ -97,12 +97,27 @@ function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-function toPerMillion(value: number | undefined, unit?: string): number {
-  if (!isPositiveNumber(value)) {
-    return 0;
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function resolveNanoGptPricingUnit(pricing: NanoGptModelPricing): string {
+  return pricing.unit ?? (pricing.inputPer1kTokens !== undefined || pricing.outputPer1kTokens !== undefined ? "per_1k_tokens" : "per_million_tokens");
+}
+
+function resolveNanoGptPricePerMillion(params: {
+  pricing: NanoGptModelPricing;
+  kind: "input" | "output";
+}): number | undefined {
+  const value =
+    params.kind === "input"
+      ? params.pricing.inputPer1kTokens ?? params.pricing.prompt
+      : params.pricing.outputPer1kTokens ?? params.pricing.completion;
+  if (!isNonNegativeNumber(value)) {
+    return undefined;
   }
 
-  return unit === "per_1k_tokens" ? value * 1000 : value;
+  return resolveNanoGptPricingUnit(params.pricing) === "per_1k_tokens" ? value * 1000 : value;
 }
 
 export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefinitionConfig | null {
@@ -113,8 +128,6 @@ export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefi
 
   const capabilities = entry.capabilities ?? {};
   const pricing = entry.pricing ?? {};
-  const pricingUnit =
-    pricing.unit ?? (pricing.inputPer1kTokens !== undefined || pricing.outputPer1kTokens !== undefined ? "per_1k_tokens" : "per_million_tokens");
   const hasVision = Boolean(capabilities.vision ?? entry.vision);
   const hasReasoning = Boolean(capabilities.reasoning ?? entry.reasoning);
   const contextWindow = entry.context_length ?? entry.contextWindow;
@@ -126,12 +139,47 @@ export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefi
     reasoning: hasReasoning,
     input: hasVision ? ["text", "image"] : ["text"],
     cost: {
-      input: toPerMillion(pricing.inputPer1kTokens ?? pricing.prompt, pricingUnit),
-      output: toPerMillion(pricing.outputPer1kTokens ?? pricing.completion, pricingUnit),
+      input: resolveNanoGptPricePerMillion({ pricing, kind: "input" }) ?? 0,
+      output: resolveNanoGptPricePerMillion({ pricing, kind: "output" }) ?? 0,
       cacheRead: 0,
       cacheWrite: 0,
     },
     contextWindow: isPositiveNumber(contextWindow) ? contextWindow : 200000,
     maxTokens: isPositiveNumber(maxTokens) ? maxTokens : 32768,
+  };
+}
+
+export function applyNanoGptProviderPricing(
+  model: ModelDefinitionConfig,
+  pricing?: NanoGptModelPricing | null,
+): ModelDefinitionConfig {
+  if (!pricing) {
+    return model;
+  }
+
+  const input = resolveNanoGptPricePerMillion({ pricing, kind: "input" });
+  const output = resolveNanoGptPricePerMillion({ pricing, kind: "output" });
+  if (input === undefined && output === undefined) {
+    return model;
+  }
+
+  const nextCost = {
+    ...model.cost,
+    ...(input === undefined ? {} : { input }),
+    ...(output === undefined ? {} : { output }),
+  };
+
+  if (
+    nextCost.input === model.cost.input &&
+    nextCost.output === model.cost.output &&
+    nextCost.cacheRead === model.cost.cacheRead &&
+    nextCost.cacheWrite === model.cost.cacheWrite
+  ) {
+    return model;
+  }
+
+  return {
+    ...model,
+    cost: nextCost,
   };
 }

--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -107,4 +107,61 @@ describe("buildNanoGptProvider", () => {
       "X-Provider": "openrouter",
     });
   });
+
+  it("surfaces provider-specific model pricing when an upstream provider is configured", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                id: "moonshotai/kimi-k2.5",
+                displayName: "Kimi K2.5",
+                pricing: {
+                  prompt: 1.5,
+                  completion: 4.5,
+                  unit: "per_million_tokens",
+                },
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            canonicalId: "moonshotai/kimi-k2.5",
+            supportsProviderSelection: true,
+            providers: [
+              {
+                provider: "openrouter",
+                available: true,
+                pricing: {
+                  inputPer1kTokens: 0.00042,
+                  outputPer1kTokens: 0.0018375,
+                  unit: "per_1k_tokens",
+                },
+              },
+            ],
+          }),
+        }),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: {
+        routingMode: "paygo",
+        catalogSource: "canonical",
+        provider: "openrouter",
+      },
+    });
+
+    expect(provider.models[0]?.id).toBe("moonshotai/kimi-k2.5");
+    expect(provider.models[0]?.cost.input).toBeCloseTo(0.42, 10);
+    expect(provider.models[0]?.cost.output).toBeCloseTo(1.8375, 10);
+    expect(provider.models[0]?.cost.cacheRead).toBe(0);
+    expect(provider.models[0]?.cost.cacheWrite).toBe(0);
+  });
 });

--- a/provider-catalog.ts
+++ b/provider-catalog.ts
@@ -29,6 +29,7 @@ export async function buildNanoGptProvider(params: {
   const models = await discoverNanoGptModels({
     apiKey: params.apiKey,
     source: catalogSource,
+    provider: config.provider,
   });
 
   return {

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -243,6 +243,123 @@ describe("discoverNanoGptModels", () => {
       },
     });
   });
+
+  it("overrides catalog pricing with the selected provider pricing when available", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          object: "list",
+          data: [
+            {
+              id: "moonshotai/kimi-k2.5",
+              name: "Kimi K2.5",
+              pricing: {
+                prompt: 1.5,
+                completion: 4.5,
+                unit: "per_million_tokens",
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          canonicalId: "moonshotai/kimi-k2.5",
+          supportsProviderSelection: true,
+          providers: [
+            {
+              provider: "openrouter",
+              available: true,
+              pricing: {
+                inputPer1kTokens: 0.00042,
+                outputPer1kTokens: 0.0018375,
+                unit: "per_1k_tokens",
+              },
+            },
+          ],
+        }),
+      });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const models = await discoverNanoGptModels({
+      apiKey: "test-key",
+      source: "canonical",
+      provider: "openrouter",
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]?.id).toBe("moonshotai/kimi-k2.5");
+    expect(models[0]?.cost.input).toBeCloseTo(0.42, 10);
+    expect(models[0]?.cost.output).toBeCloseTo(1.8375, 10);
+    expect(models[0]?.cost.cacheRead).toBe(0);
+    expect(models[0]?.cost.cacheWrite).toBe(0);
+
+    expect(String(fetchSpy.mock.calls[1]?.[0])).toBe(
+      "https://nano-gpt.com/api/models/moonshotai%2Fkimi-k2.5/providers",
+    );
+  });
+
+  it("keeps default catalog pricing when selected-provider pricing is unavailable", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          object: "list",
+          data: [
+            {
+              id: "moonshotai/kimi-k2.5",
+              name: "Kimi K2.5",
+              pricing: {
+                prompt: 1.5,
+                completion: 4.5,
+                unit: "per_million_tokens",
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          canonicalId: "moonshotai/kimi-k2.5",
+          supportsProviderSelection: true,
+          providers: [
+            {
+              provider: "other-provider",
+              available: true,
+              pricing: {
+                inputPer1kTokens: 0.00042,
+                outputPer1kTokens: 0.0018375,
+                unit: "per_1k_tokens",
+              },
+            },
+          ],
+        }),
+      });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      discoverNanoGptModels({
+        apiKey: "test-key",
+        source: "canonical",
+        provider: "openrouter",
+      }),
+    ).resolves.toMatchObject([
+      {
+        id: "moonshotai/kimi-k2.5",
+        cost: {
+          input: 1.5,
+          output: 4.5,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+      },
+    ]);
+  });
 });
 
 describe("resetNanoGptRuntimeState", () => {

--- a/runtime.ts
+++ b/runtime.ts
@@ -4,9 +4,11 @@ import {
   NANOGPT_PERSONALIZED_BASE_URL,
   NANOGPT_PAID_BASE_URL,
   NANOGPT_SUBSCRIPTION_BASE_URL,
+  applyNanoGptProviderPricing,
   buildNanoGptModelDefinition,
   type NanoGptCatalogSource,
   type NanoGptModelEntry,
+  type NanoGptModelPricing,
   type NanoGptPluginConfig,
   type NanoGptRoutingMode,
 } from "./models.js";
@@ -25,6 +27,8 @@ const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
 const NANOGPT_USAGE_PROVIDER_ID = "nanogpt" as const;
 const NANOGPT_USAGE_DISPLAY_NAME = "NanoGPT";
 const NANOGPT_USAGE_URL = `${NANOGPT_SUBSCRIPTION_BASE_URL}/usage`;
+const NANOGPT_PROVIDER_SELECTION_BASE_URL = "https://nano-gpt.com/api";
+const NANOGPT_PROVIDER_PRICING_BATCH_SIZE = 8;
 
 const subscriptionCache = new Map<string, { active: boolean; expiresAt: number }>();
 
@@ -39,6 +43,17 @@ type NanoGptUsagePayload = {
   monthly?: NanoGptUsageWindowPayload;
   limits?: Record<string, unknown> | undefined;
   period?: Record<string, unknown> | undefined;
+};
+
+type NanoGptProviderPricingEntry = {
+  provider?: unknown;
+  pricing?: unknown;
+  available?: unknown;
+};
+
+type NanoGptProviderPricingPayload = {
+  supportsProviderSelection?: unknown;
+  providers?: NanoGptProviderPricingEntry[];
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -65,6 +80,10 @@ function parseEpochMillis(value: unknown): number | undefined {
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
+}
+
+function normalizeProviderId(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
 function normalizeUsagePercent(value: number): number {
@@ -262,6 +281,7 @@ export function resolveRequestBaseUrl(routingMode: Exclude<NanoGptRoutingMode, "
 export async function discoverNanoGptModels(params: {
   apiKey: string;
   source: Exclude<NanoGptCatalogSource, "auto">;
+  provider?: string;
 }) {
   try {
     const url = new URL(`${resolveCatalogBaseUrl(params.source)}/models`);
@@ -286,10 +306,91 @@ export async function discoverNanoGptModels(params: {
     const models = entries
       .map((entry) => buildNanoGptModelDefinition(entry))
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
-    return models.length > 0 ? models : NANOGPT_FALLBACK_MODELS;
+    if (models.length === 0) {
+      return NANOGPT_FALLBACK_MODELS;
+    }
+
+    return await applyNanoGptSelectedProviderPricing({
+      apiKey: params.apiKey,
+      provider: params.provider,
+      models,
+    });
   } catch {
     return NANOGPT_FALLBACK_MODELS;
   }
+}
+
+async function fetchNanoGptSelectedProviderPricing(params: {
+  apiKey: string;
+  modelId: string;
+  provider: string;
+}): Promise<NanoGptModelPricing | null> {
+  const providerId = normalizeProviderId(params.provider);
+  if (!providerId) {
+    return null;
+  }
+
+  try {
+    const url = new URL(
+      `${NANOGPT_PROVIDER_SELECTION_BASE_URL}/models/${encodeURIComponent(params.modelId)}/providers`,
+    );
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+    });
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as NanoGptProviderPricingPayload | null;
+    if (!payload || !isRecord(payload) || payload.supportsProviderSelection === false) {
+      return null;
+    }
+
+    const providers = Array.isArray(payload.providers) ? payload.providers : [];
+    const match = providers.find(
+      (entry) =>
+        isRecord(entry) &&
+        normalizeProviderId(entry.provider) === providerId &&
+        entry.available !== false,
+    );
+    return match && isRecord(match.pricing) ? (match.pricing as NanoGptModelPricing) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function applyNanoGptSelectedProviderPricing(params: {
+  apiKey: string;
+  provider?: string;
+  models: NonNullable<Awaited<ReturnType<typeof buildNanoGptModelDefinition>>>[];
+}) {
+  const providerId = params.provider?.trim();
+  if (!providerId) {
+    return params.models;
+  }
+
+  const enriched = [...params.models];
+  for (let start = 0; start < params.models.length; start += NANOGPT_PROVIDER_PRICING_BATCH_SIZE) {
+    const chunk = params.models.slice(start, start + NANOGPT_PROVIDER_PRICING_BATCH_SIZE);
+    const chunkResults = await Promise.all(
+      chunk.map(async (model) =>
+        applyNanoGptProviderPricing(
+          model,
+          await fetchNanoGptSelectedProviderPricing({
+            apiKey: params.apiKey,
+            modelId: model.id,
+            provider: providerId,
+          }),
+        ),
+      ),
+    );
+    enriched.splice(start, chunkResults.length, ...chunkResults);
+  }
+
+  return enriched;
 }
 
 export function buildNanoGptRequestHeaders(params: {


### PR DESCRIPTION
## Summary
- align exposed `models[].cost` with NanoGPT provider-selection pricing when a fixed upstream provider is configured
- keep the existing `/models?detailed=true` pricing as the fallback when provider-specific pricing is unavailable
- add a spec document and tests covering provider-pricing enrichment behavior

## Details
- add provider-pricing enrichment on top of discovered NanoGPT model metadata
- query `GET /api/models/:canonicalId/providers` only when `plugins.entries.nanogpt.config.provider` is set
- convert NanoGPT provider pricing from per-1k-token units into the existing OpenClaw per-million-token `cost` surface
- preserve current behavior on unsupported models or endpoint failures
- document the pricing behavior in `README.md`
- fix the image-generation provider's `Buffer` return typing so `npm run typecheck` passes cleanly

## Verification
- `npm test`
- `npm run typecheck`
- live NanoGPT API sanity check using a local key alias from `~/.config/.env`
  - confirmed `GET /api/v1/models?detailed=true` returns default pricing
  - confirmed `GET /api/models/:canonicalId/providers` returns provider-specific pricing in per-1k units
  - confirmed the unit conversion target used by the implementation matches the documented/observed payload semantics