### PR TITLE
Pass NanoGPT tool capability through

### DIFF
--- a/models.test.ts
+++ b/models.test.ts
@@ -25,6 +25,7 @@ describe("buildNanoGptModelDefinition", () => {
         capabilities: {
           reasoning: true,
           vision: true,
+          tool_calling: true,
         },
         context_length: 1234,
         max_output_tokens: 567,
@@ -39,6 +40,9 @@ describe("buildNanoGptModelDefinition", () => {
       name: "GPT-5.4 Mini",
       reasoning: true,
       input: ["text", "image"],
+      compat: {
+        supportsTools: true,
+      },
       contextWindow: 1234,
       maxTokens: 567,
       cost: {
@@ -59,6 +63,36 @@ describe("buildNanoGptModelDefinition", () => {
     ).toMatchObject({
       id: "legacy-vision-model",
       input: ["text", "image"],
+    });
+  });
+
+  it.each([
+    {
+      id: "glm-5",
+      capabilities: { tool_calling: true },
+      expected: true,
+    },
+    {
+      id: "moonshotai/kimi-k2.5",
+      capabilities: { tool_calling: true },
+      expected: true,
+    },
+    {
+      id: "minimax-m2.7",
+      capabilities: { tool_calling: false },
+      expected: false,
+    },
+  ] as const)("passes through tool_calling for $id", ({ id, capabilities, expected }) => {
+    expect(
+      buildNanoGptModelDefinition({
+        id,
+        capabilities,
+      }),
+    ).toMatchObject({
+      id,
+      compat: {
+        supportsTools: expected,
+      },
     });
   });
 

--- a/models.ts
+++ b/models.ts
@@ -48,6 +48,7 @@ export interface NanoGptModelEntry {
   displayName?: string;
   reasoning?: boolean;
   vision?: boolean;
+  tool_calling?: boolean;
   capabilities?: NanoGptModelCapabilities;
   contextWindow?: number;
   context_length?: number;
@@ -130,6 +131,7 @@ export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefi
   const pricing = entry.pricing ?? {};
   const hasVision = Boolean(capabilities.vision ?? entry.vision);
   const hasReasoning = Boolean(capabilities.reasoning ?? entry.reasoning);
+  const hasTools = capabilities.tool_calling ?? entry.tool_calling;
   const contextWindow = entry.context_length ?? entry.contextWindow;
   const maxTokens = entry.max_output_tokens ?? entry.maxTokens;
 
@@ -138,6 +140,13 @@ export function buildNanoGptModelDefinition(entry: NanoGptModelEntry): ModelDefi
     name: String(entry.displayName ?? entry.name ?? id),
     reasoning: hasReasoning,
     input: hasVision ? ["text", "image"] : ["text"],
+    ...(hasTools === undefined
+      ? {}
+      : {
+          compat: {
+            supportsTools: hasTools,
+          },
+        }),
     cost: {
       input: resolveNanoGptPricePerMillion({ pricing, kind: "input" }) ?? 0,
       output: resolveNanoGptPricePerMillion({ pricing, kind: "output" }) ?? 0,

--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -50,6 +50,7 @@ describe("buildNanoGptProvider", () => {
                 capabilities: {
                   reasoning: true,
                   vision: true,
+                  tool_calling: true,
                 },
                 context_length: 200000,
                 max_output_tokens: 32768,
@@ -75,6 +76,9 @@ describe("buildNanoGptProvider", () => {
     expect(provider.models[0]).toMatchObject({
       input: ["text", "image"],
       reasoning: true,
+      compat: {
+        supportsTools: true,
+      },
       cost: {
         input: 2.5,
         output: 10,

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -210,6 +210,7 @@ describe("discoverNanoGptModels", () => {
             capabilities: {
               reasoning: true,
               vision: true,
+              tool_calling: true,
             },
             context_length: 262144,
             max_output_tokens: 8192,
@@ -235,6 +236,9 @@ describe("discoverNanoGptModels", () => {
         name: "Kimi K2.5 Thinking",
         reasoning: true,
         input: ["text", "image"],
+        compat: {
+          supportsTools: true,
+        },
         contextWindow: 262144,
         maxTokens: 8192,
         cost: {


### PR DESCRIPTION
## Summary
- Pass NanoGPT `tool_calling` through to OpenClaw `compat.supportsTools`
- Add regression coverage for discovered models and representative NanoGPT families
- Preserve the existing model discovery and provider catalog flow

## Test Plan
- npm test
- npm run typecheck