### PR TITLE
Fix NanoGPT dynamic discovery in OpenClaw catalog path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules/
+.env

--- a/docs/dynamic-discovery-debugging-method-2026-04-13.md
+++ b/docs/dynamic-discovery-debugging-method-2026-04-13.md
@@ -1,0 +1,293 @@
+# Dynamic Discovery Debugging Method
+
+**Date:** 2026-04-13  
+**Scope:** Reusable method for debugging provider plugins when dynamic model discovery appears to work internally but models do not show up in OpenClaw's user-facing catalog or picker
+
+---
+
+## Why this exists
+
+This note captures the debugging method used to fix NanoGPT dynamic discovery being dropped between:
+
+- plugin/provider discovery
+- OpenClaw implicit provider resolution
+- generated `models.json`
+- final `loadModelCatalog()` / model picker surfaces
+
+The exact bug will vary by provider, but the **method** is useful any time a plugin seems to discover models correctly while OpenClaw still shows:
+
+- fallback models only
+- `configured (not in catalog)`
+- zero models for the provider
+- models in one internal surface but not another
+
+---
+
+## The core idea
+
+Do **not** treat “model discovery is broken” as a single bug.
+
+Split it into a pipeline and prove each boundary separately:
+
+1. **External API truth** — does the upstream provider really return the models?
+2. **Plugin catalog hook** — does the plugin build the provider config with dynamic models?
+3. **Installed plugin path** — does the packaged/installed plugin expose discovery metadata correctly?
+4. **Implicit provider resolution** — does OpenClaw materialize the provider during startup/catalog generation?
+5. **Generated models file** — are the models written into OpenClaw’s generated `models.json`?
+6. **Final catalog surface** — does `loadModelCatalog()` / `openclaw models list` actually expose those models to users?
+
+If you skip one of these boundaries, it is easy to “fix” the wrong layer.
+
+---
+
+## Step-by-step method
+
+### 1. Prove the upstream API first
+
+Before touching plugin code, verify the provider actually returns the expected catalog and that the model IDs are real.
+
+For NanoGPT, that meant validating:
+
+- `GET /api/v1/models?detailed=true`
+- `GET /api/subscription/v1/models?detailed=true`
+- direct inference against the reported model IDs
+
+This avoids chasing a plugin bug when the real problem is:
+
+- wrong account tier
+- hidden/paid models
+- endpoint mismatch
+- stale assumptions about model IDs
+
+### 2. Compare the plugin contract to OpenClaw’s contract
+
+Read the plugin against the local OpenClaw source, especially:
+
+- provider discovery / catalog hooks
+- plugin manifest fields
+- final model catalog augmentation hooks
+- model picker behavior
+
+For this NanoGPT issue, the key OpenClaw seams were:
+
+- `providerDiscoveryEntry` / discovery runtime
+- provider `catalog.run(...)`
+- generated `models.json`
+- `augmentModelCatalog(...)`
+- `loadModelCatalog()`
+
+The important lesson: **a plugin can successfully build provider config while still failing to surface models in the final picker/catalog.**
+
+### 3. Add a narrow provider-hook regression first
+
+Before building a full smoke test, add the smallest regression that exercises the provider catalog hook through OpenClaw’s discovery path.
+
+Goal:
+
+- prove the plugin returns real discovered models
+- prove it does not fall back unexpectedly
+- keep the test cheap and diagnostic
+
+For NanoGPT, this caught the installed/discovery boundary separately from the final catalog boundary.
+
+### 4. Test the packaged install path, not just the workspace path
+
+If the bug is about discovery inside OpenClaw, **test the installed plugin**.
+
+Use an isolated temp state dir so the real setup is untouched.
+
+Useful environment knobs:
+
+- `OPENCLAW_STATE_DIR`
+- `OPENCLAW_AGENT_DIR`
+- `OPENCLAW_CONFIG_PATH`
+
+Recommended install flow:
+
+1. create a temp state dir
+2. `npm pack`
+3. `openclaw plugins install <tgz>` into the temp state dir
+4. write a minimal temp OpenClaw config that explicitly trusts/enables the plugin
+
+Why `npm pack` instead of installing the checkout directly:
+
+- it exercises the real package contents
+- it catches missing `files` entries
+- it avoids false positives from workspace-only paths
+- it avoids symlink/safety-scan issues from linked dev dependencies
+
+### 5. Inspect both `models.json` and the final catalog
+
+This is the most important “don’t stop too early” step.
+
+You need to inspect **both**:
+
+- the generated provider data in `models.json`
+- the final user-facing catalog returned by `loadModelCatalog()` / `openclaw models list`
+
+Why:
+
+- models can exist in `models.json` but still be missing from the final catalog
+- this means the provider-discovery stage worked, but the last surfacing step failed
+
+That exact pattern happened here:
+
+- NanoGPT models were present in generated `models.json`
+- but `openclaw models list --provider nanogpt` still showed zero models
+
+That immediately localizes the bug to the **final catalog augmentation / picker exposure layer**, not raw discovery.
+
+### 6. If the CLI disagrees with internals, trust the user-facing discrepancy
+
+A provider hook passing is good.
+A generated `models.json` being populated is also good.
+
+But if the actual CLI or picker still shows no models, the bug is **not fixed yet**.
+
+The debugging mindset should be:
+
+- internal success is evidence
+- user-facing success is the acceptance test
+
+### 7. Fix the last missing boundary, then re-run the packaged smoke test
+
+In this case, the final missing step was to re-surface NanoGPT’s discovered models back into the final catalog via plugin-owned augmentation.
+
+The fix was not “change upstream OpenClaw”.
+It was to make the plugin participate correctly in the catalog pipeline.
+
+After that, re-run the full packaged smoke test and verify:
+
+- installed plugin path
+- CLI listing
+- `loadModelCatalog()` output
+- model count
+- sample IDs
+- whether the result is fallback-only or truly dynamic
+
+---
+
+## Practical command pattern
+
+### Safe sandbox pattern
+
+Use a fresh sandbox so debugging does not touch the real OpenClaw install:
+
+```bash
+export OPENCLAW_STATE_DIR="$(mktemp -d /tmp/openclaw-provider-debug.XXXXXX)"
+export OPENCLAW_AGENT_DIR="$OPENCLAW_STATE_DIR/agents/default/agent"
+export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+```
+
+### Real install path pattern
+
+```bash
+npm pack --pack-destination "$OPENCLAW_STATE_DIR"
+openclaw plugins install "$OPENCLAW_STATE_DIR/<package>.tgz" --force
+```
+
+### Minimal plugin-enable config pattern
+
+```json
+{
+  "plugins": {
+    "allow": ["nanogpt"],
+    "entries": {
+      "nanogpt": {
+        "enabled": true,
+        "config": {
+          "routingMode": "auto",
+          "catalogSource": "auto"
+        }
+      }
+    }
+  }
+}
+```
+
+### Full catalog probe pattern
+
+If CLI output is noisy or mixed with logs, probe the model catalog directly:
+
+- load config from the temp config path
+- call `loadModelCatalog({ config, useCache: false })`
+- filter `provider === "nanogpt"`
+- inspect counts and sample IDs
+- compare against known fallback IDs
+
+---
+
+## Heuristics that helped in this case
+
+### Heuristic 1: If the provider hook returns zero models, suspect auth first
+
+NanoGPT’s `provider-discovery.ts` returns `null` when `ctx.resolveProviderApiKey("nanogpt").apiKey` is missing.
+
+So:
+
+- zero provider result often means auth/config/env resolution failed
+- not necessarily that upstream discovery or response parsing failed
+
+### Heuristic 2: If `models.json` has models but the CLI does not, suspect final catalog augmentation
+
+That pattern usually means:
+
+- discovery succeeded
+- persistence succeeded
+- user-facing surfacing failed
+
+### Heuristic 3: A clean provider-hook test is necessary but not sufficient
+
+A provider hook can be correct while the actual user experience is still broken.
+
+### Heuristic 4: Always inspect the installed package contents
+
+Check that the installed package actually contains:
+
+- manifest metadata
+- discovery entry files
+- any newly added files listed in `package.json` `files`
+
+Otherwise a workspace-only fix may never reach users.
+
+---
+
+## What this method found for NanoGPT
+
+Using the method above, the real sequence was:
+
+1. NanoGPT upstream APIs returned the expected models.
+2. The plugin’s provider discovery hook could return dynamic models.
+3. The installed package needed correct discovery metadata/file exposure.
+4. OpenClaw generated `models.json` with NanoGPT models.
+5. The final user-facing catalog still dropped them.
+6. The plugin needed a final catalog augmentation step to re-surface those models as `nanogpt/...` entries.
+
+That distinction was the key. Without checking both `models.json` and `loadModelCatalog()`, it would have been easy to stop too early and think the problem was solved.
+
+---
+
+## Future checklist
+
+When dynamic discovery looks broken, follow this order:
+
+- [ ] Verify the upstream API returns the expected models.
+- [ ] Verify the plugin’s provider/catalog hook returns dynamic models.
+- [ ] Verify the installed package contains the new discovery files/manifest fields.
+- [ ] Verify OpenClaw implicit provider resolution includes the plugin.
+- [ ] Inspect generated `models.json` for the provider.
+- [ ] Inspect `loadModelCatalog()` / CLI model listing.
+- [ ] Compare the final result against the fallback model set.
+- [ ] Add one narrow regression and one installed-path smoke test.
+
+---
+
+## Recommendation
+
+For future provider-plugin work, treat discovery bugs as **pipeline bugs** until proven otherwise.
+
+Debugging gets much faster once you explicitly ask:
+
+> At which exact boundary do the models disappear?
+
+That question turned this from a vague “autodiscovery broken” issue into a concrete, fixable sequence.

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
@@ -21,6 +24,12 @@ describe("nanogpt plugin entry", () => {
           baseUrl?: string;
           models?: Array<Record<string, unknown>>;
         };
+      }) => unknown;
+      augmentModelCatalog?: (ctx: {
+        agentDir?: string;
+        config?: Record<string, unknown>;
+        env?: Record<string, string | undefined>;
+        entries: Array<Record<string, unknown>>;
       }) => unknown;
       resolveDynamicModel?: (ctx: {
         provider: string;
@@ -169,6 +178,56 @@ describe("nanogpt plugin entry", () => {
       },
     });
     expect(responsesApiResult).toBeNull();
+  });
+
+  it("surfaces discovered NanoGPT models from models.json into catalog augmentation", () => {
+    const provider = getRegisteredProvider();
+
+    expect(provider.augmentModelCatalog).toEqual(expect.any(Function));
+
+    const agentDir = mkdtempSync(join(tmpdir(), "nanogpt-agent-"));
+    writeFileSync(
+      join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            nanogpt: {
+              api: "openai-completions",
+              baseUrl: "https://nano-gpt.com/api/subscription/v1",
+              models: [
+                {
+                  id: "openai/gpt-oss-120b",
+                  name: "GPT OSS 120B",
+                  reasoning: true,
+                  input: ["text"],
+                  contextWindow: 131072,
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(
+      provider.augmentModelCatalog?.({
+        agentDir,
+        config: {},
+        env: {},
+        entries: [],
+      }),
+    ).toMatchObject([
+      {
+        provider: "nanogpt",
+        id: "openai/gpt-oss-120b",
+        name: "GPT OSS 120B",
+        reasoning: true,
+        input: ["text"],
+        contextWindow: 131072,
+      },
+    ]);
   });
 
   it("resolves unknown NanoGPT model ids dynamically without rewriting them", () => {

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs";
+import path from "node:path";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { buildNanoGptImageGenerationProvider } from "./image-generation-provider.js";
 import { applyNanoGptProviderConfig } from "./onboard.js";
 import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
@@ -12,6 +15,117 @@ import {
 import { createNanoGptWebSearchProvider } from "./web-search.js";
 import type { ProviderCatalogContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+type NanoGptCatalogEntry = {
+  provider: string;
+  id: string;
+  name: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+  input?: Array<"text" | "image" | "document">;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeNanoGptCatalogInput(
+  input: unknown,
+): NanoGptCatalogEntry["input"] | undefined {
+  if (!Array.isArray(input)) {
+    return undefined;
+  }
+
+  const normalized = input.filter(
+    (item): item is "text" | "image" | "document" =>
+      item === "text" || item === "image" || item === "document",
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function readNanoGptModelsJsonCatalogEntries(agentDir?: string): NanoGptCatalogEntry[] {
+  if (!agentDir) {
+    return [];
+  }
+
+  const modelsPath = path.join(agentDir, "models.json");
+  try {
+    if (!fs.existsSync(modelsPath)) {
+      return [];
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(modelsPath, "utf8")) as unknown;
+    const providers = isRecord(parsed) && isRecord(parsed.providers) ? parsed.providers : undefined;
+    const provider = providers && isRecord(providers[NANOGPT_PROVIDER_ID])
+      ? providers[NANOGPT_PROVIDER_ID]
+      : undefined;
+    const models = provider && Array.isArray(provider.models) ? provider.models : [];
+
+    const entries: NanoGptCatalogEntry[] = [];
+    for (const model of models) {
+      if (!isRecord(model)) {
+        continue;
+      }
+
+      const id = typeof model.id === "string" ? model.id.trim() : "";
+      if (!id) {
+        continue;
+      }
+
+      const name = (typeof model.name === "string" ? model.name : id).trim() || id;
+      const contextWindow =
+        typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow) && model.contextWindow > 0
+          ? model.contextWindow
+          : undefined;
+      const reasoning = typeof model.reasoning === "boolean" ? model.reasoning : undefined;
+      const input = normalizeNanoGptCatalogInput(model.input);
+
+      entries.push({
+        provider: NANOGPT_PROVIDER_ID,
+        id,
+        name,
+        ...(contextWindow ? { contextWindow } : {}),
+        ...(reasoning !== undefined ? { reasoning } : {}),
+        ...(input ? { input } : {}),
+      });
+    }
+
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+function mergeNanoGptCatalogEntries(...groups: NanoGptCatalogEntry[][]): NanoGptCatalogEntry[] {
+  const seen = new Set<string>();
+  const merged: NanoGptCatalogEntry[] = [];
+
+  for (const group of groups) {
+    for (const entry of group) {
+      const key = `${entry.provider}::${entry.id}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      merged.push(entry);
+    }
+  }
+
+  return merged;
+}
+
+function readNanoGptAugmentedCatalogEntries(params: {
+  agentDir?: string;
+  config?: unknown;
+}): NanoGptCatalogEntry[] {
+  return mergeNanoGptCatalogEntries(
+    readNanoGptModelsJsonCatalogEntries(params.agentDir),
+    readConfiguredProviderCatalogEntries({
+      config: params.config as import("openclaw/plugin-sdk/provider-onboard").OpenClawConfig | undefined,
+      providerId: NANOGPT_PROVIDER_ID,
+    }),
+  );
+}
 
 function applyNanoGptNativeStreamingUsageCompat(
   providerConfig: ModelProviderConfig,
@@ -90,6 +204,11 @@ export default definePluginEntry({
           };
         },
       },
+      augmentModelCatalog: (ctx) =>
+        readNanoGptAugmentedCatalogEntries({
+          agentDir: ctx.agentDir,
+          config: ctx.config,
+        }),
       resolveDynamicModel: (ctx) => resolveNanoGptDynamicModel(ctx),
       applyNativeStreamingUsageCompat: ({ providerConfig }) =>
         applyNanoGptNativeStreamingUsageCompat(providerConfig),

--- a/openclaw-discovery.test.ts
+++ b/openclaw-discovery.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizePluginDiscoveryResult,
+  resolvePluginDiscoveryProviders,
+  runProviderCatalog,
+} from "./node_modules/openclaw/src/plugins/provider-discovery.js";
+import type { ProviderPlugin } from "./node_modules/openclaw/src/plugins/types.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  nanoGptCatalogProviderPromise = undefined;
+});
+
+let nanoGptCatalogProviderPromise: Promise<ProviderPlugin | undefined> | undefined;
+
+async function loadNanoGptCatalogProvider(): Promise<ProviderPlugin | undefined> {
+  nanoGptCatalogProviderPromise ??= resolvePluginDiscoveryProviders({
+    config: {
+      plugins: {
+        allow: ["nanogpt"],
+        entries: {
+          nanogpt: {
+            enabled: true,
+            config: {
+              routingMode: "auto",
+              catalogSource: "auto",
+            },
+          },
+        },
+      },
+    },
+    workspaceDir: process.cwd(),
+    env: {
+      ...process.env,
+      OPENCLAW_TEST_ONLY_PROVIDER_PLUGIN_IDS: "nanogpt",
+      VITEST: "1",
+      NODE_ENV: "test",
+    },
+    onlyPluginIds: ["nanogpt"],
+  }).then((providers) => providers.find((provider) => provider.id === "nanogpt"));
+
+  return nanoGptCatalogProviderPromise;
+}
+
+describe("NanoGPT OpenClaw discovery integration", () => {
+  it(
+    "returns discovered NanoGPT models through the OpenClaw provider catalog hook",
+    async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ subscribed: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          object: "list",
+          data: [
+            {
+              id: "moonshotai/kimi-k2.5:thinking",
+              displayName: "Kimi K2.5 Thinking",
+              capabilities: {
+                reasoning: true,
+                vision: true,
+                tool_calling: true,
+              },
+              context_length: 262144,
+              max_output_tokens: 8192,
+              pricing: {
+                prompt: 1.5,
+                completion: 4.5,
+                unit: "per_million_tokens",
+              },
+            },
+          ],
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+      const provider = await loadNanoGptCatalogProvider();
+    expect(provider).toBeDefined();
+
+      const result = await runProviderCatalog({
+        provider: provider!,
+        config: {
+        plugins: {
+          allow: ["nanogpt"],
+          entries: {
+            nanogpt: {
+              enabled: true,
+              config: {
+                routingMode: "auto",
+                catalogSource: "auto",
+              },
+            },
+          },
+        },
+      },
+        agentDir: process.cwd(),
+        workspaceDir: process.cwd(),
+        env: {
+        ...process.env,
+        OPENCLAW_TEST_ONLY_PROVIDER_PLUGIN_IDS: "nanogpt",
+        VITEST: "1",
+        NODE_ENV: "test",
+        },
+        resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+        resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        discoveryApiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+        }),
+      });
+
+      const providers = normalizePluginDiscoveryResult({
+        provider: provider!,
+        result,
+      });
+
+      expect(providers.nanogpt).toMatchObject({
+      api: "openai-completions",
+      baseUrl: "https://nano-gpt.com/api/subscription/v1",
+      models: [
+        expect.objectContaining({
+          id: "moonshotai/kimi-k2.5:thinking",
+          name: "Kimi K2.5 Thinking",
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: 262144,
+          maxTokens: 8192,
+          cost: {
+            input: 1.5,
+            output: 4.5,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        }),
+      ],
+    });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://nano-gpt.com/api/subscription/v1/usage",
+      );
+      expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      "https://nano-gpt.com/api/subscription/v1/models?detailed=true",
+      );
+    },
+    30_000,
+  );
+});

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "nanogpt",
   "name": "NanoGPT",
   "description": "NanoGPT provider plugin for OpenClaw",
+  "providerDiscoveryEntry": "./provider-discovery.ts",
   "providers": [
     "nanogpt"
   ],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "models.ts",
     "runtime.ts",
     "provider-catalog.ts",
+    "provider-discovery.ts",
     "image-generation-provider.ts",
     "web-search.ts",
     "onboard.ts",

--- a/provider-discovery.ts
+++ b/provider-discovery.ts
@@ -1,0 +1,33 @@
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildNanoGptProvider } from "./provider-catalog.js";
+import { NANOGPT_PROVIDER_ID } from "./models.js";
+
+function resolveNanoGptPluginConfig(ctx: ProviderCatalogContext): unknown {
+  const entries = (ctx.config.plugins?.entries ?? {}) as Record<string, { config?: unknown }>;
+  return entries[NANOGPT_PROVIDER_ID]?.config;
+}
+
+const nanoGptProviderDiscovery = {
+  id: NANOGPT_PROVIDER_ID,
+  label: "NanoGPT",
+  docsPath: "/providers/models",
+  auth: [],
+  catalog: {
+    order: "simple" as const,
+    run: async (ctx: ProviderCatalogContext) => {
+      const apiKey = ctx.resolveProviderApiKey(NANOGPT_PROVIDER_ID).apiKey;
+      if (!apiKey) {
+        return null;
+      }
+
+      return {
+        provider: await buildNanoGptProvider({
+          apiKey,
+          pluginConfig: resolveNanoGptPluginConfig(ctx),
+        }),
+      };
+    },
+  },
+};
+
+export default nanoGptProviderDiscovery;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "skipLibCheck": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["*.ts"]
+  "include": ["*.ts"],
+  "exclude": ["openclaw-discovery.test.ts"]
 }


### PR DESCRIPTION
Summary
This fixes NanoGPT dynamic model discovery being dropped between provider discovery and OpenClaw’s final model catalog / picker surfaces.

What changed
add a lightweight NanoGPT providerDiscoveryEntry so installed plugins participate correctly in OpenClaw’s provider discovery flow
surface NanoGPT discovered models back into the final catalog via plugin-owned catalog augmentation
add regression coverage for:
OpenClaw provider discovery / catalog hook behavior
models.json → final catalog augmentation behavior
document the debugging method used to isolate this class of discovery bug for future provider work
Why this was needed
NanoGPT discovery was working internally, but models could still disappear before the final user-facing catalog. In practice that led to fallback-only behavior or NanoGPT models not appearing in picker/list surfaces even though provider discovery had succeeded.

The fix makes the plugin participate in the full OpenClaw discovery pipeline instead of stopping at the provider-config generation step.

Validation
npm test
npm run typecheck
packaged install smoke test using an isolated OPENCLAW_STATE_DIR
confirmed installed plugin metadata includes the NanoGPT discovery entry
confirmed openclaw models list --all --provider nanogpt --plain shows dynamic nanogpt/... entries
confirmed OpenClaw’s final loadModelCatalog() path includes hundreds of NanoGPT models and is not fallback-only
Notes
no upstream openclaw changes were required
the debugging method write-up is included at:
dynamic-discovery-debugging-method-2026-04-13.md