### PR TITLE
Fix NanoGPT metadata hydration in OpenClaw listings

### DIFF
--- a/docs/model-metadata-debugging-method-2026-04-13.md
+++ b/docs/model-metadata-debugging-method-2026-04-13.md
@@ -1,0 +1,314 @@
+# Model Metadata Debugging Method
+
+**Date:** 2026-04-13  
+**Scope:** Reusable method for debugging cases where provider model discovery succeeds, but `openclaw models list --json` shows flattened metadata such as identical context windows, text-only input, or missing token limits
+
+---
+
+## Why this exists
+
+This note captures the debugging method used after NanoGPT dynamic discovery was already fixed, but the user-facing command:
+
+- `openclaw models list --all --json --provider nanogpt`
+
+still appeared wrong.
+
+The specific symptoms were:
+
+- all models appeared to have the same `contextWindow`
+- all models looked text-only
+- `maxTokens` was missing from the JSON rows
+
+At first glance this looked like a broken model-catalog mapping. It turned out to be a more specific pipeline bug in the **dynamic-model fallback path** used by the list command.
+
+---
+
+## The core idea
+
+When a list or picker surface looks flattened, do **not** assume the provider catalog itself is bad.
+
+Instead, ask:
+
+> Is the metadata wrong at the source, or only wrong in the final presentation path?
+
+For model metadata bugs, split the system into these layers:
+
+1. **Provider API payload**
+2. **Plugin model-definition mapping**
+3. **Generated `models.json` provider config**
+4. **Raw discovered model registry**
+5. **Dynamic-model fallback path**
+6. **List/picker row formatting**
+
+The fix depends entirely on which layer first loses fidelity.
+
+---
+
+## The debugging method
+
+### 1. Reproduce the exact user-facing command
+
+Start with the exact command the user runs, not a nearby approximation.
+
+Example:
+
+```bash
+openclaw models list --all --json --provider nanogpt
+```
+
+Important details:
+
+- capture both stdout and stderr
+- strip ANSI color codes before parsing
+- many OpenClaw CLI commands prepend log lines before the JSON payload
+- do not assume stdout is pure JSON from byte 0
+
+A useful parsing approach is:
+
+- remove ANSI escapes
+- skip non-JSON prefix lines
+- parse the first actual JSON object/array
+
+This matters because a command may appear “broken” when the parser is simply choking on a log prefix like:
+
+- `[agents] synced openai-codex credentials from external cli`
+
+### 2. Verify whether the JSON is truly flattened
+
+Once parsed, measure the shape instead of relying on a few eyeballed rows.
+
+Useful checks:
+
+- total item count
+- number of distinct `contextWindow` values
+- number of models whose `input` includes image (or `text+image` in summary form)
+- sample entries for likely multimodal or high-context families
+
+For NanoGPT, the bad state looked like:
+
+- 607 models
+- exactly 1 distinct `contextWindow`
+- 0 multimodal models
+- text-only rows
+
+That confirmed the flattening was systematic, not cosmetic.
+
+### 3. Inspect the generated `models.json`
+
+The next step is to inspect the provider data OpenClaw generated for runtime use:
+
+- `<agentDir>/models.json`
+
+This is critical because `models.json` is often richer than the final CLI/list rows.
+
+For NanoGPT, `models.json` showed:
+
+- many distinct context windows
+- many multimodal models
+- realistic `maxTokens`
+- correct reasoning/tool metadata
+
+That immediately ruled out:
+
+- upstream API failure
+- provider payload parsing failure
+- plugin model-definition mapping failure
+- provider catalog generation failure
+
+So the bug had to be **after** `models.json` generation.
+
+### 4. Inspect the raw discovered registry
+
+Next, inspect the raw discovered model registry used by OpenClaw before final row formatting.
+
+Ask:
+
+- does the raw registry contain provider models at all?
+- if it does, is the metadata rich or already flattened?
+
+In this NanoGPT investigation, the raw registry path was illuminating:
+
+- the raw registry did **not** expose NanoGPT entries directly in the list-command path
+
+That meant the list command was not reading rich NanoGPT models directly from the discovered registry.
+
+This is the key pivot point.
+
+### 5. Check whether the list command is falling back to dynamic-model resolution
+
+If the raw registry does not directly expose the provider’s models, OpenClaw may still build list rows by taking catalog entries and re-resolving them through:
+
+- `resolveModelWithRegistry(...)`
+- plugin `resolveDynamicModel(...)`
+- plugin `normalizeResolvedModel(...)`
+
+This is where a provider can accidentally lose metadata fidelity.
+
+For NanoGPT, that is exactly what happened.
+
+OpenClaw’s list path was resolving NanoGPT rows through a dynamic-model fallback path where:
+
+- `providerConfig.models` was empty
+- `agentDir` was sometimes not passed into the hook context
+
+Without those, the plugin’s dynamic resolver only had generic defaults available, so it produced rows like:
+
+- `input: ["text"]`
+- `contextWindow: 200000`
+- `maxTokens: 32768`
+
+which then surfaced as flattened list output.
+
+### 6. Distinguish row-summary JSON from raw provider metadata
+
+Another subtlety: `openclaw models list --json` does **not** emit the raw provider model-definition objects.
+
+It emits row-oriented summary objects.
+
+That means:
+
+- `input` may be summarized as a display string like `text` or `text+image`
+- `maxTokens` may be absent even when the underlying model has it
+- some provider metadata is intentionally condensed for the listing surface
+
+So always distinguish between:
+
+- **raw provider config / models.json fidelity**, and
+- **row-summary JSON fidelity**
+
+The command can be correct as a summary surface while still omitting raw fields by design.
+
+The real bug is when it collapses values that should remain distinguishable.
+
+### 7. Rehydrate the fallback path from the rich snapshot
+
+Once the failure was localized, the fix was not to change the provider API mapping.
+
+The fix was to teach the fallback runtime path to reuse the rich `models.json` snapshot when:
+
+- OpenClaw resolves a NanoGPT model dynamically
+- `providerConfig.models` is unavailable or empty
+- `agentDir` is missing from the hook context
+
+The practical strategy was:
+
+- parse `models.json`
+- cache a provider-specific snapshot
+- use it to rehydrate:
+  - `input`
+  - `contextWindow`
+  - `maxTokens`
+  - `reasoning`
+  - `cost`
+  - `compat`
+- fall back to environment/default agent-dir resolution if `agentDir` is not passed
+
+That turns a generic fallback model into the real provider-specific model again.
+
+---
+
+## Useful heuristics
+
+### Heuristic 1: If `models.json` is rich, the provider catalog is probably fine
+
+Do not keep debugging the upstream provider payload if `models.json` already contains the correct metadata.
+
+### Heuristic 2: If the raw registry is empty for the provider, inspect dynamic fallback immediately
+
+That usually means the list surface is being reconstructed indirectly.
+
+### Heuristic 3: Missing `agentDir` is a silent metadata killer
+
+Provider hooks that depend on generated files like `models.json` may silently degrade if the caller omits `agentDir`.
+
+If the metadata looks suspiciously default-shaped, inspect whether the hook has enough context to find the generated files.
+
+### Heuristic 4: Identical large-scale values are usually a fallback signature
+
+If hundreds of models all show the same values, such as:
+
+- `contextWindow = 200000`
+- `input = text`
+
+that is a strong sign you are seeing a fallback/default path, not real provider metadata.
+
+### Heuristic 5: A passing provider hook test is still not enough
+
+A provider can be correct in:
+
+- discovery
+- catalog generation
+- `models.json`
+
+and still be wrong in:
+
+- row-building
+- runtime re-resolution
+- summary formatting
+
+Always test the actual user-facing command.
+
+---
+
+## Practical sandbox pattern
+
+For safe debugging, use an isolated state dir:
+
+```bash
+export OPENCLAW_STATE_DIR="$(mktemp -d /tmp/openclaw-provider-debug.XXXXXX)"
+export OPENCLAW_AGENT_DIR="$OPENCLAW_STATE_DIR/agents/default/agent"
+export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+```
+
+Then:
+
+1. source your provider API key from a local `.env`
+2. `npm pack`
+3. `openclaw plugins install <tgz>`
+4. write a minimal config enabling/trusting the plugin
+5. run the exact `models list` command
+6. inspect both:
+   - the parsed CLI JSON
+   - `models.json`
+
+This isolates the command behavior from the user’s live config and installed plugins.
+
+---
+
+## What this method found for NanoGPT
+
+Using this method, the sequence was:
+
+1. `openclaw models list --json` looked flattened.
+2. The generated NanoGPT `models.json` was rich and correct.
+3. The raw discovered registry did not surface NanoGPT models directly in the relevant path.
+4. OpenClaw re-resolved the rows through NanoGPT’s dynamic-model fallback path.
+5. That fallback path lacked `providerConfig.models` and sometimes `agentDir`.
+6. The plugin therefore used generic defaults instead of rich provider metadata.
+7. The fix was to rehydrate that fallback path from the generated `models.json` snapshot.
+
+---
+
+## Future checklist
+
+When a provider list/picker surface looks flattened, follow this order:
+
+- [ ] Reproduce the exact user-facing command.
+- [ ] Parse the real JSON payload after stripping logs/ANSI.
+- [ ] Measure distinct metadata values instead of eyeballing.
+- [ ] Inspect the provider section inside generated `models.json`.
+- [ ] Inspect the raw discovered model registry.
+- [ ] Check whether OpenClaw is falling back to `resolveDynamicModel()`.
+- [ ] Verify whether the hook has `providerConfig.models` and `agentDir`.
+- [ ] Rehydrate the fallback path from generated provider metadata if needed.
+- [ ] Add a regression for the missing-context path.
+
+---
+
+## Recommendation
+
+For metadata bugs, ask this before changing any API mapping code:
+
+> Are we looking at the real provider metadata, or at a default-shaped fallback object built later in the runtime pipeline?
+
+That question saved a lot of time here.

--- a/index.test.ts
+++ b/index.test.ts
@@ -406,6 +406,76 @@ describe("nanogpt plugin entry", () => {
     });
   });
 
+  it("falls back to OPENCLAW_AGENT_DIR when dynamic model resolution omits agentDir", () => {
+    const provider = getRegisteredProvider();
+
+    expect(provider.resolveDynamicModel).toEqual(expect.any(Function));
+
+    const agentDir = mkdtempSync(join(tmpdir(), "nanogpt-agent-"));
+    writeFileSync(
+      join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            nanogpt: {
+              api: "openai-completions",
+              baseUrl: "https://nano-gpt.com/api/subscription/v1",
+              models: [
+                {
+                  id: "openai/gpt-5.4-mini",
+                  name: "GPT-5.4 Mini",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: {
+                    input: 0.15,
+                    output: 0.6,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  contextWindow: 400000,
+                  maxTokens: 128000,
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const previousAgentDir = process.env.OPENCLAW_AGENT_DIR;
+    process.env.OPENCLAW_AGENT_DIR = agentDir;
+
+    try {
+      expect(
+        provider.resolveDynamicModel?.({
+          provider: "nanogpt",
+          modelId: "openai/gpt-5.4-mini",
+          modelRegistry: {},
+          providerConfig: {
+            api: "openai-completions",
+            baseUrl: "https://nano-gpt.com/api/v1",
+            models: [],
+          },
+        }),
+      ).toMatchObject({
+        id: "openai/gpt-5.4-mini",
+        name: "GPT-5.4 Mini",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 400000,
+        maxTokens: 128000,
+      });
+    } finally {
+      if (previousAgentDir === undefined) {
+        delete process.env.OPENCLAW_AGENT_DIR;
+      } else {
+        process.env.OPENCLAW_AGENT_DIR = previousAgentDir;
+      }
+    }
+  });
+
   it("resolves unknown NanoGPT model ids dynamically without rewriting them", () => {
     const provider = getRegisteredProvider();
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -31,6 +31,29 @@ describe("nanogpt plugin entry", () => {
         env?: Record<string, string | undefined>;
         entries: Array<Record<string, unknown>>;
       }) => unknown;
+      normalizeResolvedModel?: (ctx: {
+        agentDir?: string;
+        provider: string;
+        modelId: string;
+        model: {
+          id: string;
+          name: string;
+          provider: string;
+          api: string;
+          baseUrl?: string;
+          reasoning: boolean;
+          input: Array<"text" | "image" | "document">;
+          cost: {
+            input: number;
+            output: number;
+            cacheRead: number;
+            cacheWrite: number;
+          };
+          contextWindow: number;
+          maxTokens: number;
+          compat?: Record<string, unknown>;
+        };
+      }) => unknown;
       resolveDynamicModel?: (ctx: {
         provider: string;
         modelId: string;
@@ -228,6 +251,83 @@ describe("nanogpt plugin entry", () => {
         contextWindow: 131072,
       },
     ]);
+  });
+
+  it("rehydrates flattened discovered NanoGPT metadata from models.json", () => {
+    const provider = getRegisteredProvider();
+
+    expect(provider.normalizeResolvedModel).toEqual(expect.any(Function));
+
+    const agentDir = mkdtempSync(join(tmpdir(), "nanogpt-agent-"));
+    writeFileSync(
+      join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            nanogpt: {
+              api: "openai-completions",
+              baseUrl: "https://nano-gpt.com/api/subscription/v1",
+              models: [
+                {
+                  id: "openai/gpt-5.4-mini",
+                  name: "GPT-5.4 Mini",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: {
+                    input: 0.15,
+                    output: 0.6,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  contextWindow: 400000,
+                  maxTokens: 128000,
+                  compat: {
+                    supportsTools: true,
+                  },
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(
+      provider.normalizeResolvedModel?.({
+        agentDir,
+        provider: "nanogpt",
+        modelId: "openai/gpt-5.4-mini",
+        model: {
+          id: "openai/gpt-5.4-mini",
+          name: "openai/gpt-5.4-mini",
+          provider: "nanogpt",
+          api: "openai-completions",
+          baseUrl: "https://nano-gpt.com/api/v1",
+          reasoning: false,
+          input: ["text"],
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          contextWindow: 200000,
+          maxTokens: 32768,
+        },
+      }),
+    ).toMatchObject({
+      id: "openai/gpt-5.4-mini",
+      name: "GPT-5.4 Mini",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 400000,
+      maxTokens: 128000,
+      compat: {
+        supportsTools: true,
+      },
+    });
   });
 
   it("resolves unknown NanoGPT model ids dynamically without rewriting them", () => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -55,6 +55,7 @@ describe("nanogpt plugin entry", () => {
         };
       }) => unknown;
       resolveDynamicModel?: (ctx: {
+        agentDir?: string;
         provider: string;
         modelId: string;
         modelRegistry: unknown;
@@ -326,6 +327,81 @@ describe("nanogpt plugin entry", () => {
       maxTokens: 128000,
       compat: {
         supportsTools: true,
+      },
+    });
+  });
+
+  it("uses models.json metadata when dynamic model resolution has no provider model templates", () => {
+    const provider = getRegisteredProvider();
+
+    expect(provider.resolveDynamicModel).toEqual(expect.any(Function));
+
+    const agentDir = mkdtempSync(join(tmpdir(), "nanogpt-agent-"));
+    writeFileSync(
+      join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            nanogpt: {
+              api: "openai-completions",
+              baseUrl: "https://nano-gpt.com/api/subscription/v1",
+              models: [
+                {
+                  id: "openai/gpt-5.4-mini",
+                  name: "GPT-5.4 Mini",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: {
+                    input: 0.15,
+                    output: 0.6,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  contextWindow: 400000,
+                  maxTokens: 128000,
+                  compat: {
+                    supportsTools: true,
+                  },
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(
+      provider.resolveDynamicModel?.({
+        agentDir,
+        provider: "nanogpt",
+        modelId: "openai/gpt-5.4-mini",
+        modelRegistry: {},
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://nano-gpt.com/api/v1",
+          models: [],
+        },
+      }),
+    ).toMatchObject({
+      id: "openai/gpt-5.4-mini",
+      name: "GPT-5.4 Mini",
+      provider: "nanogpt",
+      api: "openai-completions",
+      baseUrl: "https://nano-gpt.com/api/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 400000,
+      maxTokens: 128000,
+      compat: {
+        supportsTools: true,
+      },
+      cost: {
+        input: 0.15,
+        output: 0.6,
+        cacheRead: 0,
+        cacheWrite: 0,
       },
     });
   });

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,11 @@ import {
   resolveNanoGptUsageAuth,
 } from "./runtime.js";
 import { createNanoGptWebSearchProvider } from "./web-search.js";
-import type { ProviderCatalogContext, ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  ProviderCatalogContext,
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
 type NanoGptCatalogEntry = {
@@ -270,6 +274,26 @@ function normalizeNanoGptResolvedModel(
   return changed ? nextModel : undefined;
 }
 
+function resolveNanoGptDynamicModelWithSnapshot(
+  ctx: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel | undefined {
+  const snapshotModels = [...readNanoGptModelsJsonSnapshot(ctx.agentDir).modelDefinitions.values()];
+
+  return resolveNanoGptDynamicModel({
+    ...ctx,
+    providerConfig:
+      ctx.providerConfig || snapshotModels.length > 0
+        ? {
+            ...ctx.providerConfig,
+            models:
+              Array.isArray(ctx.providerConfig?.models) && ctx.providerConfig.models.length > 0
+                ? ctx.providerConfig.models
+                : snapshotModels,
+          }
+        : ctx.providerConfig,
+  });
+}
+
 function applyNanoGptNativeStreamingUsageCompat(
   providerConfig: ModelProviderConfig,
 ): ModelProviderConfig | null {
@@ -357,7 +381,7 @@ export default definePluginEntry({
           agentDir: ctx.agentDir,
           model: ctx.model,
         }),
-      resolveDynamicModel: (ctx) => resolveNanoGptDynamicModel(ctx),
+      resolveDynamicModel: (ctx) => resolveNanoGptDynamicModelWithSnapshot(ctx),
       applyNativeStreamingUsageCompat: ({ providerConfig }) =>
         applyNanoGptNativeStreamingUsageCompat(providerConfig),
       resolveUsageAuth: async (ctx) => await resolveNanoGptUsageAuth(ctx),

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ import {
   resolveNanoGptUsageAuth,
 } from "./runtime.js";
 import { createNanoGptWebSearchProvider } from "./web-search.js";
-import type { ProviderCatalogContext } from "openclaw/plugin-sdk/plugin-entry";
+import type { ProviderCatalogContext, ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
 type NanoGptCatalogEntry = {
@@ -24,6 +24,21 @@ type NanoGptCatalogEntry = {
   reasoning?: boolean;
   input?: Array<"text" | "image" | "document">;
 };
+
+type NanoGptModelsJsonSnapshot = {
+  catalogEntries: NanoGptCatalogEntry[];
+  modelDefinitions: Map<string, ModelProviderConfig["models"][number]>;
+};
+
+const emptyNanoGptModelsJsonSnapshot: NanoGptModelsJsonSnapshot = {
+  catalogEntries: [],
+  modelDefinitions: new Map<string, ModelProviderConfig["models"][number]>(),
+};
+
+const nanoGptModelsJsonCache = new Map<
+  string,
+  { mtimeMs: number; snapshot: NanoGptModelsJsonSnapshot }
+>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -43,15 +58,68 @@ function normalizeNanoGptCatalogInput(
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function readNanoGptModelsJsonCatalogEntries(agentDir?: string): NanoGptCatalogEntry[] {
+function normalizeNanoGptProviderModelInput(
+  input: unknown,
+): Array<"text" | "image"> | undefined {
+  if (!Array.isArray(input)) {
+    return undefined;
+  }
+
+  const normalized = input.filter(
+    (item): item is "text" | "image" => item === "text" || item === "image",
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function parseFinitePositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function buildNanoGptModelsJsonCost(
+  value: unknown,
+): ModelProviderConfig["models"][number]["cost"] {
+  const record = isRecord(value) ? value : {};
+  const input = typeof record.input === "number" && Number.isFinite(record.input) ? record.input : 0;
+  const output = typeof record.output === "number" && Number.isFinite(record.output) ? record.output : 0;
+  const cacheRead =
+    typeof record.cacheRead === "number" && Number.isFinite(record.cacheRead) ? record.cacheRead : 0;
+  const cacheWrite =
+    typeof record.cacheWrite === "number" && Number.isFinite(record.cacheWrite) ? record.cacheWrite : 0;
+
+  return { input, output, cacheRead, cacheWrite };
+}
+
+function buildNanoGptCatalogEntryFromModelDefinition(
+  model: ModelProviderConfig["models"][number],
+): NanoGptCatalogEntry {
+  return {
+    provider: NANOGPT_PROVIDER_ID,
+    id: model.id,
+    name: model.name,
+    ...(typeof model.contextWindow === "number" && model.contextWindow > 0
+      ? { contextWindow: model.contextWindow }
+      : {}),
+    ...(typeof model.reasoning === "boolean" ? { reasoning: model.reasoning } : {}),
+    ...(Array.isArray(model.input) && model.input.length > 0 ? { input: [...model.input] } : {}),
+  };
+}
+
+function readNanoGptModelsJsonSnapshot(agentDir?: string): NanoGptModelsJsonSnapshot {
   if (!agentDir) {
-    return [];
+    return emptyNanoGptModelsJsonSnapshot;
   }
 
   const modelsPath = path.join(agentDir, "models.json");
   try {
     if (!fs.existsSync(modelsPath)) {
-      return [];
+      nanoGptModelsJsonCache.delete(modelsPath);
+      return emptyNanoGptModelsJsonSnapshot;
+    }
+
+    const stats = fs.statSync(modelsPath);
+    const cached = nanoGptModelsJsonCache.get(modelsPath);
+    if (cached && cached.mtimeMs === stats.mtimeMs) {
+      return cached.snapshot;
     }
 
     const parsed = JSON.parse(fs.readFileSync(modelsPath, "utf8")) as unknown;
@@ -61,7 +129,8 @@ function readNanoGptModelsJsonCatalogEntries(agentDir?: string): NanoGptCatalogE
       : undefined;
     const models = provider && Array.isArray(provider.models) ? provider.models : [];
 
-    const entries: NanoGptCatalogEntry[] = [];
+    const catalogEntries: NanoGptCatalogEntry[] = [];
+    const modelDefinitions = new Map<string, ModelProviderConfig["models"][number]>();
     for (const model of models) {
       if (!isRecord(model)) {
         continue;
@@ -73,26 +142,58 @@ function readNanoGptModelsJsonCatalogEntries(agentDir?: string): NanoGptCatalogE
       }
 
       const name = (typeof model.name === "string" ? model.name : id).trim() || id;
-      const contextWindow =
-        typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow) && model.contextWindow > 0
-          ? model.contextWindow
-          : undefined;
-      const reasoning = typeof model.reasoning === "boolean" ? model.reasoning : undefined;
-      const input = normalizeNanoGptCatalogInput(model.input);
+      const contextWindow = parseFinitePositiveNumber(model.contextWindow) ?? 200000;
+      const contextTokens = parseFinitePositiveNumber(model.contextTokens);
+      const maxTokens = parseFinitePositiveNumber(model.maxTokens) ?? 32768;
+      const reasoning = typeof model.reasoning === "boolean" ? model.reasoning : false;
+      const catalogInput = normalizeNanoGptCatalogInput(model.input);
+      const providerModelInput = normalizeNanoGptProviderModelInput(model.input);
 
-      entries.push({
+      const definition: ModelProviderConfig["models"][number] = {
+        id,
+        name,
+        reasoning,
+        input: providerModelInput ? [...providerModelInput] : ["text"],
+        cost: buildNanoGptModelsJsonCost(model.cost),
+        contextWindow,
+        ...(contextTokens ? { contextTokens } : {}),
+        maxTokens,
+        ...(isRecord(model.compat)
+          ? {
+              compat: {
+                ...(model.compat as NonNullable<ModelProviderConfig["models"][number]["compat"]>),
+              },
+            }
+          : {}),
+        ...(typeof model.api === "string"
+          ? { api: model.api as ModelProviderConfig["models"][number]["api"] }
+          : {}),
+      };
+
+      catalogEntries.push({
         provider: NANOGPT_PROVIDER_ID,
         id,
         name,
         ...(contextWindow ? { contextWindow } : {}),
-        ...(reasoning !== undefined ? { reasoning } : {}),
-        ...(input ? { input } : {}),
+        ...(typeof reasoning === "boolean" ? { reasoning } : {}),
+        ...(catalogInput ? { input: [...catalogInput] } : {}),
       });
+      modelDefinitions.set(id, definition);
     }
 
-    return entries;
+    const snapshot = {
+      catalogEntries,
+      modelDefinitions,
+    } satisfies NanoGptModelsJsonSnapshot;
+    nanoGptModelsJsonCache.set(modelsPath, {
+      mtimeMs: stats.mtimeMs,
+      snapshot,
+    });
+
+    return snapshot;
   } catch {
-    return [];
+    nanoGptModelsJsonCache.delete(modelsPath);
+    return emptyNanoGptModelsJsonSnapshot;
   }
 }
 
@@ -119,12 +220,54 @@ function readNanoGptAugmentedCatalogEntries(params: {
   config?: unknown;
 }): NanoGptCatalogEntry[] {
   return mergeNanoGptCatalogEntries(
-    readNanoGptModelsJsonCatalogEntries(params.agentDir),
+    readNanoGptModelsJsonSnapshot(params.agentDir).catalogEntries,
     readConfiguredProviderCatalogEntries({
       config: params.config as import("openclaw/plugin-sdk/provider-onboard").OpenClawConfig | undefined,
       providerId: NANOGPT_PROVIDER_ID,
     }),
   );
+}
+
+function normalizeNanoGptResolvedModel(
+  ctx: { agentDir?: string; model: ProviderRuntimeModel },
+): ProviderRuntimeModel | undefined {
+  const definition = readNanoGptModelsJsonSnapshot(ctx.agentDir).modelDefinitions.get(ctx.model.id);
+  if (!definition) {
+    return undefined;
+  }
+
+  const nextModel: ProviderRuntimeModel = {
+    ...ctx.model,
+    name: definition.name,
+    reasoning: definition.reasoning,
+    input: [...definition.input],
+    cost: { ...definition.cost },
+    contextWindow: definition.contextWindow,
+    maxTokens: definition.maxTokens,
+    ...(definition.contextTokens ? { contextTokens: definition.contextTokens } : {}),
+    ...(definition.compat
+      ? {
+          compat: {
+            ...ctx.model.compat,
+            ...definition.compat,
+          },
+        }
+      : {}),
+    ...(definition.api ? { api: definition.api } : {}),
+  };
+
+  const changed =
+    nextModel.name !== ctx.model.name ||
+    nextModel.reasoning !== ctx.model.reasoning ||
+    nextModel.contextWindow !== ctx.model.contextWindow ||
+    nextModel.maxTokens !== ctx.model.maxTokens ||
+    nextModel.contextTokens !== ctx.model.contextTokens ||
+    JSON.stringify(nextModel.input) !== JSON.stringify(ctx.model.input) ||
+    JSON.stringify(nextModel.cost) !== JSON.stringify(ctx.model.cost) ||
+    JSON.stringify(nextModel.compat ?? null) !== JSON.stringify(ctx.model.compat ?? null) ||
+    nextModel.api !== ctx.model.api;
+
+  return changed ? nextModel : undefined;
 }
 
 function applyNanoGptNativeStreamingUsageCompat(
@@ -208,6 +351,11 @@ export default definePluginEntry({
         readNanoGptAugmentedCatalogEntries({
           agentDir: ctx.agentDir,
           config: ctx.config,
+        }),
+      normalizeResolvedModel: (ctx) =>
+        normalizeNanoGptResolvedModel({
+          agentDir: ctx.agentDir,
+          model: ctx.model,
         }),
       resolveDynamicModel: (ctx) => resolveNanoGptDynamicModel(ctx),
       applyNativeStreamingUsageCompat: ({ providerConfig }) =>

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
@@ -108,12 +109,33 @@ function buildNanoGptCatalogEntryFromModelDefinition(
   };
 }
 
+function resolveNanoGptAgentDir(agentDir?: string): string | undefined {
+  const explicit = typeof agentDir === "string" && agentDir.trim() ? agentDir.trim() : undefined;
+  if (explicit) {
+    return explicit;
+  }
+
+  const envAgentDir = process.env.OPENCLAW_AGENT_DIR?.trim() || process.env.PI_CODING_AGENT_DIR?.trim();
+  if (envAgentDir) {
+    return envAgentDir;
+  }
+
+  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (stateDir) {
+    return path.join(stateDir, "agents", "default", "agent");
+  }
+
+  const homeDir = process.env.OPENCLAW_HOME?.trim() || process.env.HOME?.trim() || os.homedir();
+  return homeDir ? path.join(homeDir, ".openclaw", "agents", "default", "agent") : undefined;
+}
+
 function readNanoGptModelsJsonSnapshot(agentDir?: string): NanoGptModelsJsonSnapshot {
-  if (!agentDir) {
+  const resolvedAgentDir = resolveNanoGptAgentDir(agentDir);
+  if (!resolvedAgentDir) {
     return emptyNanoGptModelsJsonSnapshot;
   }
 
-  const modelsPath = path.join(agentDir, "models.json");
+  const modelsPath = path.join(resolvedAgentDir, "models.json");
   try {
     if (!fs.existsSync(modelsPath)) {
       nanoGptModelsJsonCache.delete(modelsPath);


### PR DESCRIPTION
## Summary

Fix NanoGPT model metadata getting flattened in OpenClaw listing surfaces even when dynamic discovery had already succeeded.

## What changed

- rehydrate NanoGPT model metadata from the generated `models.json` snapshot during runtime/dynamic resolution
- fall back to `OPENCLAW_AGENT_DIR` / `OPENCLAW_STATE_DIR` / default agent paths when `agentDir` is omitted from the runtime hook context
- preserve rich per-model metadata in the `openclaw models list --all --json --provider nanogpt` path instead of falling back to generic defaults
- add regression coverage for:
  - resolved-model normalization from `models.json`
  - dynamic-model resolution without provider model templates
  - dynamic-model resolution when `agentDir` is omitted
- add a second debugging-method note documenting how to debug flattened metadata/listing bugs:
  - `docs/model-metadata-debugging-method-2026-04-13.md`

## Why this was needed

NanoGPT dynamic discovery could succeed and produce rich provider metadata in `models.json`, but the final OpenClaw list/json surfaces could still show flattened rows such as:

- identical `contextWindow`
- text-only `input`
- missing token limits

The root cause was the runtime fallback path resolving NanoGPT models without access to the rich model templates, causing generic defaults to be used.

## Validation

- `npm test`
- `npm run typecheck`
- fresh sandboxed install via `npm pack` + `openclaw plugins install`
- verified `openclaw models list --all --json --provider nanogpt` in a fresh sandbox now reports:
  - 607 models
  - 57 distinct `contextWindow` values
  - 198 image-capable models

Fixes #10