### PR TITLE
🧪 Add error handling tests for discoverNanoGptModels

### DIFF
--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { NANOGPT_FALLBACK_MODELS } from "./models.js";
 import {
   buildNanoGptRequestHeaders,
   discoverNanoGptModels,
@@ -397,6 +398,70 @@ describe("discoverNanoGptModels", () => {
         },
       },
     ]);
+  });
+
+  it("returns fallback models when fetch throws an error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network failure")));
+
+    await expect(
+      discoverNanoGptModels({
+        apiKey: "test-key",
+        source: "canonical",
+      }),
+    ).resolves.toEqual(NANOGPT_FALLBACK_MODELS);
+  });
+
+  it("returns fallback models when response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }),
+    );
+
+    await expect(
+      discoverNanoGptModels({
+        apiKey: "test-key",
+        source: "canonical",
+      }),
+    ).resolves.toEqual(NANOGPT_FALLBACK_MODELS);
+  });
+
+  it("returns fallback models when response is invalid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error("Invalid JSON");
+        },
+      }),
+    );
+
+    await expect(
+      discoverNanoGptModels({
+        apiKey: "test-key",
+        source: "canonical",
+      }),
+    ).resolves.toEqual(NANOGPT_FALLBACK_MODELS);
+  });
+
+  it("returns fallback models when model list is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      }),
+    );
+
+    await expect(
+      discoverNanoGptModels({
+        apiKey: "test-key",
+        source: "canonical",
+      }),
+    ).resolves.toEqual(NANOGPT_FALLBACK_MODELS);
   });
 });
 


### PR DESCRIPTION
This PR adds comprehensive error handling tests for the `discoverNanoGptModels` function in `runtime.ts`.

### 🎯 What
The testing gap addressed was the lack of verification for how `discoverNanoGptModels` behaves when external API calls fail or return unexpected data.

### 📊 Coverage
The following scenarios are now explicitly tested:
- **Network failure:** Mocking `fetch` to reject with an error.
- **HTTP status error:** Mocking `fetch` to return a non-OK status (e.g., 500).
- **Invalid JSON:** Mocking the response to throw during JSON parsing.
- **Empty dataset:** Mocking the response to return an empty data array.

### ✨ Result
These tests ensure that the function robustly falls back to `NANOGPT_FALLBACK_MODELS`, preventing model discovery failures from breaking the provider's integration with OpenClaw. Over-reaching changes to `package-lock.json` accidentally introduced during development were reverted to maintain project integrity.

---
*PR created automatically by Jules for task [4910622466108527009](https://jules.google.com/task/4910622466108527009) started by @deadronos*