### PR TITLE
🔒 Fix HTTP Header Injection via API Key

### DIFF
--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -1,3 +1,4 @@
+import { sanitizeApiKey } from "./runtime.js";
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 
@@ -130,7 +131,7 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
       const response = await fetch(`${NANOGPT_IMAGE_BASE_URL}/v1/images/generations`, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${auth.apiKey}`,
+          Authorization: `Bearer ${sanitizeApiKey(auth.apiKey)}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(body),

--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -135,6 +135,31 @@ describe("buildNanoGptProvider", () => {
     });
   });
 
+  it("sanitizes provider override headers before returning the provider config", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" }] }),
+      })),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: {
+        routingMode: "subscription",
+        catalogSource: "subscription",
+        provider: "openrouter\r\nInjected: true",
+      },
+    });
+
+    expect(provider.headers).toEqual({
+      Authorization: "Bearer test-key",
+      "X-Billing-Mode": "paygo",
+      "X-Provider": "openrouterInjected: true",
+    });
+  });
+
   it("surfaces provider-specific model pricing when an upstream provider is configured", async () => {
     vi.stubGlobal(
       "fetch",

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  sanitizeApiKey,
   buildNanoGptRequestHeaders,
   discoverNanoGptModels,
   fetchNanoGptUsageSnapshot,
@@ -16,6 +17,14 @@ import {
 afterEach(() => {
   resetNanoGptRuntimeState();
   vi.unstubAllGlobals();
+});
+
+describe("sanitizeApiKey", () => {
+  it("removes carriage returns and line feeds to prevent HTTP header injection", () => {
+    expect(sanitizeApiKey("test-key")).toBe("test-key");
+    expect(sanitizeApiKey("test-key\r\nInjected: true")).toBe("test-keyInjected: true");
+    expect(sanitizeApiKey("\ntest\r")).toBe("test");
+  });
 });
 
 describe("getNanoGptConfig", () => {

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -147,6 +147,20 @@ describe("buildNanoGptRequestHeaders", () => {
       "X-Provider": "openrouter",
     });
   });
+
+  it("sanitizes provider header values before sending them", () => {
+    expect(
+      buildNanoGptRequestHeaders({
+        apiKey: "test-key\r\nInjected: true",
+        config: { provider: "openrouter\r\nInjected: true" },
+        routingMode: "subscription",
+      }),
+    ).toEqual({
+      Authorization: "Bearer test-keyInjected: true",
+      "X-Billing-Mode": "paygo",
+      "X-Provider": "openrouterInjected: true",
+    });
+  });
 });
 
 describe("resolveNanoGptUsageAuth", () => {

--- a/runtime.ts
+++ b/runtime.ts
@@ -27,6 +27,10 @@ import type {
   ProviderResolveUsageAuthContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 
+export function sanitizeApiKey(apiKey: string): string {
+  return apiKey.replace(/[\r\n]/g, "");
+}
+
 const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
 const NANOGPT_USAGE_PROVIDER_ID = "nanogpt" as const;
 const NANOGPT_USAGE_DISPLAY_NAME = "NanoGPT";
@@ -281,7 +285,7 @@ export async function probeNanoGptSubscription(apiKey: string): Promise<boolean>
     const response = await fetch(`${NANOGPT_SUBSCRIPTION_BASE_URL}/usage`, {
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${sanitizeApiKey(apiKey)}`,
       },
     });
 
@@ -364,7 +368,7 @@ export async function discoverNanoGptModels(params: {
     const response = await fetch(url, {
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
+        Authorization: `Bearer ${sanitizeApiKey(params.apiKey)}`,
       },
     });
     if (!response.ok) {
@@ -411,7 +415,7 @@ async function fetchNanoGptSelectedProviderPricing(params: {
     const response = await fetch(url, {
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
+        Authorization: `Bearer ${sanitizeApiKey(params.apiKey)}`,
       },
     });
     if (!response.ok) {
@@ -473,7 +477,7 @@ export function buildNanoGptRequestHeaders(params: {
   routingMode: Exclude<NanoGptRoutingMode, "auto">;
 }): Record<string, string> {
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${params.apiKey}`,
+    Authorization: `Bearer ${sanitizeApiKey(params.apiKey)}`,
   };
 
   if (params.config.provider) {
@@ -504,7 +508,7 @@ export async function fetchNanoGptUsageSnapshot(
     {
       method: "GET",
       headers: {
-        Authorization: `Bearer ${ctx.token}`,
+        Authorization: `Bearer ${sanitizeApiKey(ctx.token)}`,
         Accept: "application/json",
       },
     },

--- a/runtime.ts
+++ b/runtime.ts
@@ -27,8 +27,12 @@ import type {
   ProviderResolveUsageAuthContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]/g, "");
+}
+
 export function sanitizeApiKey(apiKey: string): string {
-  return apiKey.replace(/[\r\n]/g, "");
+  return sanitizeHeaderValue(apiKey);
 }
 
 const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
@@ -481,7 +485,7 @@ export function buildNanoGptRequestHeaders(params: {
   };
 
   if (params.config.provider) {
-    headers["X-Provider"] = params.config.provider;
+    headers["X-Provider"] = sanitizeHeaderValue(params.config.provider);
     if (params.routingMode === "subscription") {
       headers["X-Billing-Mode"] = "paygo";
     }

--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 import { createNanoGptWebSearchProvider } from "./web-search.js";
+
+let originalNanoGptApiKey: string | undefined;
+
+beforeEach(() => {
+  originalNanoGptApiKey = process.env.NANOGPT_API_KEY;
+  delete process.env.NANOGPT_API_KEY;
+});
 
 describe("nanogpt web search provider", () => {
   it("registers the nanogpt web search provider", () => {
@@ -123,4 +130,15 @@ describe("nanogpt web search provider", () => {
       ],
     });
   });
+});
+
+afterEach(() => {
+  if (originalNanoGptApiKey === undefined) {
+    delete process.env.NANOGPT_API_KEY;
+  } else {
+    process.env.NANOGPT_API_KEY = originalNanoGptApiKey;
+  }
+  originalNanoGptApiKey = undefined;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });

--- a/web-search.ts
+++ b/web-search.ts
@@ -1,3 +1,4 @@
+import { sanitizeApiKey } from "./runtime.js";
 import {
   enablePluginInConfig,
   readNumberParam,
@@ -159,7 +160,7 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         const response = await fetch(NANOGPT_WEB_SEARCH_URL, {
           method: "POST",
           headers: {
-            Authorization: `Bearer ${apiKey}`,
+            Authorization: `Bearer ${sanitizeApiKey(apiKey)}`,
             "Content-Type": "application/json",
             Accept: "application/json",
           },


### PR DESCRIPTION
🎯 **What:**
The vulnerability allowed HTTP Header Injection due to an improperly validated API Key being injected into the 'Authorization: Bearer' header inside `runtime.ts`, `image-generation-provider.ts`, and `web-search.ts`.

⚠️ **Risk:**
If an API key originating from an untrusted source or config file contains carriage return (`\r`) and line feed (`\n`) characters, it could inject additional headers or alter requests.

🛡️ **Solution:**
Created a `sanitizeApiKey` helper function in `runtime.ts` that removes carriage returns and line feeds. Applied this sanitization across all code paths interpolating the API key into HTTP headers.

---
*PR created automatically by Jules for task [305107695700866938](https://jules.google.com/task/305107695700866938) started by @deadronos*