### PR TITLE
🔒 add missing validation on image generation size

### DIFF
--- a/image-generation-provider.test.ts
+++ b/image-generation-provider.test.ts
@@ -206,5 +206,25 @@ describe("nanogpt image-generation provider", () => {
     ).rejects.toThrow(
       /Try one of: hidream, chroma, z-image-turbo, qwen-image-2512/i,
     );
-  });
+    });
+
+  it("throws an error when an invalid image size is provided", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "test-key",
+      source: "env",
+      mode: "api-key",
+    });
+
+    const provider = buildNanoGptImageGenerationProvider();
+
+    await expect(
+      provider.generateImage({
+        provider: "nanogpt",
+        model: "hidream",
+        prompt: "test prompt",
+        cfg: {},
+        size: "9999x9999" as any,
+      }),
+    ).rejects.toThrow(/Invalid image size "9999x9999"/);
+});
 });

--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -105,6 +105,9 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
       const model = normalizeImageModelName(requestedModel);
       const count = req.count ?? 1;
       const size = req.size ?? "1024x1024";
+      if (size && !NANOGPT_IMAGE_SIZES.includes(size as any)) {
+        throw new Error(`Invalid image size "${size}". Expected one of: ${NANOGPT_IMAGE_SIZES.join(", ")}`);
+      }
       const inputImages = req.inputImages ?? [];
       const body: Record<string, unknown> = {
         model,


### PR DESCRIPTION
🎯 What: The size parameter in image generation requests was passed to the API without validating if it was supported.
⚠️ Risk: An attacker or incorrect client implementation could pass unsupported image sizes, potentially resulting in downstream errors, excessive compute overhead, or unhandled exceptions on the server.
🛡️ Solution: Validated the size variable against the predefined NANOGPT_IMAGE_SIZES array. If the size is invalid, an error is proactively thrown before the API call.

---
*PR created automatically by Jules for task [16117919456227831215](https://jules.google.com/task/16117919456227831215) started by @deadronos*