### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS risk in web search results

### DIFF
--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -158,6 +158,39 @@ describe("nanogpt web search provider", () => {
       ],
     });
   });
+
+  it("normalizes NanoGPT search results and blocks untrusted URL protocols", async () => {
+    const { __testing } = await import("./web-search.js");
+
+    expect(
+      __testing.normalizeNanoGptWebSearchResult({
+        title: "Malicious Link",
+        url: "javascript:alert(1)",
+        snippet: "Click me",
+      })
+    ).toBeNull();
+
+    expect(
+      __testing.normalizeNanoGptWebSearchResult({
+        title: "Malicious Link",
+        url: "data:text/html,<script>alert(1)</script>",
+        snippet: "Click me",
+      })
+    ).toBeNull();
+
+    expect(
+      __testing.normalizeNanoGptWebSearchResult({
+        title: "Valid Link",
+        url: "https://example.com/docs",
+        snippet: "Valid click",
+      })
+    ).toMatchObject({
+      title: expect.any(String),
+      url: "https://example.com/docs",
+      snippet: expect.any(String),
+      siteName: "example.com",
+    });
+  });
 });
 
 afterEach(() => {

--- a/web-search.ts
+++ b/web-search.ts
@@ -92,6 +92,16 @@ function normalizeNanoGptWebSearchResult(
     return null;
   }
 
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    return null;
+  }
+
   const title = typeof entry.title === "string" ? entry.title.trim() : "";
   const rawSnippet =
     typeof entry.snippet === "string"


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS risk in web search results

🚨 Severity: HIGH
💡 Vulnerability: The `normalizeNanoGptWebSearchResult` function did not validate the protocol of the returned URLs. If an upstream search result returned a malicious URL such as `javascript:alert(1)` or a `data:` URI, the frontend could inadvertently execute XSS.
🎯 Impact: An attacker or untrusted search result could lead to XSS execution on the client if they click the malicious search result URL.
🔧 Fix: Updated the normalizer to parse the `URL` and explicitly require either `http:` or `https:` protocols. If a URL uses another protocol, the URL will be filtered out (returning `null`).
✅ Verification: Added test cases to `web-search.test.ts` to ensure `javascript:` and `data:` URIs are effectively filtered and `https:` URLs are preserved. Verified changes locally using `vitest run web-search.test.ts`.

---
*PR created automatically by Jules for task [6333634605833947990](https://jules.google.com/task/6333634605833947990) started by @deadronos*