### PR TITLE
Omit Authorization header for runtime injection

### DIFF
--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -129,7 +129,6 @@ describe("buildNanoGptProvider", () => {
     });
 
     expect(provider.headers).toEqual({
-      Authorization: "Bearer test-key",
       "X-Billing-Mode": "paygo",
       "X-Provider": "openrouter",
     });
@@ -154,10 +153,29 @@ describe("buildNanoGptProvider", () => {
     });
 
     expect(provider.headers).toEqual({
-      Authorization: "Bearer test-key",
       "X-Billing-Mode": "paygo",
       "X-Provider": "openrouterInjected: true",
     });
+  });
+
+  it("omits Authorization from provider config so runtime auth can inject the real key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" }] }),
+      })),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: {
+        routingMode: "subscription",
+        catalogSource: "subscription",
+      },
+    });
+
+    expect(provider.headers).toBeUndefined();
   });
 
   it("surfaces provider-specific model pricing when an upstream provider is configured", async () => {

--- a/provider-catalog.ts
+++ b/provider-catalog.ts
@@ -84,6 +84,13 @@ export async function buildNanoGptProvider(params: {
     throw new Error(validationError);
   }
 
+  const resolvedHeaders = buildNanoGptRequestHeaders({
+    apiKey: params.apiKey,
+    config,
+    routingMode,
+  });
+  const { Authorization: _authorization, ...providerHeaders } = resolvedHeaders;
+
   return {
     baseUrl: resolveRequestBaseUrl({
       config,
@@ -91,11 +98,7 @@ export async function buildNanoGptProvider(params: {
     }),
     api: resolveNanoGptRequestApi(config),
     apiKey: params.apiKey,
-    headers: buildNanoGptRequestHeaders({
-      apiKey: params.apiKey,
-      config,
-      routingMode,
-    }),
+    ...(Object.keys(providerHeaders).length > 0 ? { headers: providerHeaders } : {}),
     models: models.map((model) => ({
       ...model,
       provider: NANOGPT_PROVIDER_ID,


### PR DESCRIPTION
Remove the Authorization header from the provider configuration to allow runtime authentication to inject the actual key. This change enhances security by preventing hardcoded credentials.