### PR TITLE
Add subscription state handling and routing logic

### DIFF
--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -110,6 +110,37 @@ describe("buildNanoGptProvider", () => {
     });
   });
 
+  it("keeps subscription routing when the usage probe only reports state=active", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ state: "active" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                id: "moonshotai/kimi-k2.5:thinking",
+                displayName: "Kimi K2.5 Thinking",
+              },
+            ],
+          }),
+        }),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: { routingMode: "auto", catalogSource: "auto" },
+    });
+
+    expect(provider.baseUrl).toBe("https://nano-gpt.com/api/subscription/v1");
+    expect(provider.models[0]?.id).toBe("moonshotai/kimi-k2.5:thinking");
+  });
+
   it("adds provider override headers and paygo billing override for subscription routing", async () => {
     vi.stubGlobal(
       "fetch",

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -73,6 +73,44 @@ describe("resolveNanoGptRoutingMode", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("treats a state-only active usage payload as subscription", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ state: "active" }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "state-only-key",
+      }),
+    ).resolves.toBe("subscription");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a future grace period as subscription", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        state: "grace",
+        active: false,
+        graceUntil: Date.now() + 60_000,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "grace-key",
+      }),
+    ).resolves.toBe("subscription");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("caches subscription status per api key", async () => {
     const fetchSpy = vi
       .fn()

--- a/runtime.ts
+++ b/runtime.ts
@@ -50,6 +50,7 @@ const providerPricingInFlight = new Map<string, Promise<NanoGptModelPricing | nu
 type NanoGptUsageWindowPayload = Record<string, unknown> | number | string | undefined;
 
 type NanoGptUsagePayload = {
+  subscribed?: unknown;
   active?: unknown;
   state?: unknown;
   plan?: unknown;
@@ -215,6 +216,68 @@ function resolveNanoGptUsagePlan(payload: NanoGptUsagePayload): string | undefin
   return typeof payload.active === "boolean" ? (payload.active ? "active" : "inactive") : undefined;
 }
 
+function resolveNanoGptSubscriptionState(value: unknown): boolean | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (
+    normalized === "active" ||
+    normalized === "subscribed" ||
+    normalized === "grace" ||
+    normalized === "grace_period" ||
+    normalized === "grace-period" ||
+    normalized === "trial" ||
+    normalized === "trialing"
+  ) {
+    return true;
+  }
+
+  if (
+    normalized === "inactive" ||
+    normalized === "expired" ||
+    normalized === "unsubscribed" ||
+    normalized === "cancelled" ||
+    normalized === "canceled" ||
+    normalized === "none"
+  ) {
+    return false;
+  }
+
+  return undefined;
+}
+
+function hasNanoGptFutureGracePeriod(value: unknown): boolean {
+  const graceUntil = parseEpochMillis(value);
+  return typeof graceUntil === "number" && graceUntil > Date.now();
+}
+
+function resolveNanoGptSubscriptionActive(payload: NanoGptUsagePayload): boolean {
+  const subscribed = typeof payload.subscribed === "boolean" ? payload.subscribed : undefined;
+  const active = typeof payload.active === "boolean" ? payload.active : undefined;
+  const state = resolveNanoGptSubscriptionState(payload.state);
+  const plan = resolveNanoGptSubscriptionState(payload.plan);
+
+  if (subscribed === true || active === true || state === true || plan === true) {
+    return true;
+  }
+
+  if (hasNanoGptFutureGracePeriod(payload.graceUntil)) {
+    return true;
+  }
+
+  if (subscribed === false || active === false || state === false || plan === false) {
+    return false;
+  }
+
+  return false;
+}
+
 function buildNanoGptUsageErrorSnapshot(error: string): ProviderUsageSnapshot {
   return {
     provider: NANOGPT_USAGE_PROVIDER_ID as ProviderUsageSnapshot["provider"],
@@ -312,8 +375,8 @@ export async function probeNanoGptSubscription(apiKey: string): Promise<boolean>
       throw new Error(`NanoGPT subscription probe failed with HTTP ${response.status}`);
     }
 
-    const payload = (await response.json()) as { subscribed?: boolean; active?: boolean };
-    const active = Boolean(payload.subscribed ?? payload.active);
+    const payload = (await response.json()) as NanoGptUsagePayload;
+    const active = resolveNanoGptSubscriptionActive(payload);
     subscriptionCache.set(apiKey, { active, expiresAt: now + SUBSCRIPTION_CACHE_TTL_MS });
     return active;
   } catch (error) {


### PR DESCRIPTION
Implement logic to handle subscription states and routing based on usage probe responses. This includes treating specific states as subscriptions and caching subscription status per API key. Tests ensure correct behavior for various subscription scenarios.