### PR TITLE
Enhance subscription routing logic on probe errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The plugin config controls NanoGPT text-model discovery and transport behavior:
 ## Model Allowlist in openclaw.json
 
 For example:
+
 ```json5
 "agents":{
   "defaults":{
@@ -144,7 +145,6 @@ For example:
 "
 ```
 
-
 ### Options
 
 - `routingMode`: `auto`, `subscription`, `paygo`
@@ -155,7 +155,9 @@ For example:
 ### Behavior notes
 
 - `routingMode: "auto"` probes NanoGPT subscription status and falls back to
-  `paygo` if the probe fails.
+  `subscription` if the probe is ambiguous or fails. It only resolves to
+  `paygo` when the probe succeeds and explicitly indicates the key is not
+  subscription-active.
 - `catalogSource: "auto"` resolves to `subscription` when text requests are
   routed through subscription mode, otherwise `canonical`.
 - `requestApi: "responses"` uses OpenAI Responses transport (experimental, requires models compatible with Responses API).
@@ -166,6 +168,10 @@ For example:
 - `provider` adds NanoGPT's `X-Provider` override header for text requests.
 - if `provider` is set while the request would otherwise use subscription
   routing, the plugin also sets `X-Billing-Mode: paygo`
+- `requestApi: "responses"` on subscription routing uses NanoGPT's base API
+  endpoint (`/api/v1`) rather than the subscription completions endpoint, so
+  treat it as a separate compatibility/billing path from standard subscription
+  chat-completions routing.
 
 ### Pricing behavior
 

--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -141,6 +141,34 @@ describe("buildNanoGptProvider", () => {
     expect(provider.models[0]?.id).toBe("moonshotai/kimi-k2.5:thinking");
   });
 
+  it("keeps subscription routing when the usage probe errors in auto mode", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error("usage probe failed"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                id: "moonshotai/kimi-k2.5:thinking",
+                displayName: "Kimi K2.5 Thinking",
+              },
+            ],
+          }),
+        }),
+    );
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: { routingMode: "auto", catalogSource: "auto" },
+    });
+
+    expect(provider.baseUrl).toBe("https://nano-gpt.com/api/subscription/v1");
+    expect(provider.models[0]?.id).toBe("moonshotai/kimi-k2.5:thinking");
+  });
+
   it("adds provider override headers and paygo billing override for subscription routing", async () => {
     vi.stubGlobal(
       "fetch",

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -111,6 +111,20 @@ describe("resolveNanoGptRoutingMode", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("favors subscription when the usage probe errors in auto mode", async () => {
+    const fetchSpy = vi.fn().mockRejectedValue(new Error("usage probe failed"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveNanoGptRoutingMode({
+        config: { routingMode: "auto" },
+        apiKey: "probe-error-key",
+      }),
+    ).resolves.toBe("subscription");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("caches subscription status per api key", async () => {
     const fetchSpy = vi
       .fn()
@@ -150,6 +164,10 @@ describe("resolveNanoGptRoutingMode", () => {
 describe("resolveCatalogSource", () => {
   it("maps auto to subscription when routing resolved to subscription", () => {
     expect(resolveCatalogSource({ config: {}, routingMode: "subscription" })).toBe("subscription");
+  });
+
+  it("maps auto to canonical when routing resolved to paygo", () => {
+    expect(resolveCatalogSource({ config: {}, routingMode: "paygo" })).toBe("canonical");
   });
 });
 
@@ -199,6 +217,18 @@ describe("buildNanoGptRequestHeaders", () => {
       Authorization: "Bearer test-keyInjected: true",
       "X-Billing-Mode": "paygo",
       "X-Provider": "openrouterInjected: true",
+    });
+  });
+
+  it("does not set a paygo billing override when no provider override is configured", () => {
+    expect(
+      buildNanoGptRequestHeaders({
+        apiKey: "test-key",
+        config: {},
+        routingMode: "subscription",
+      }),
+    ).toEqual({
+      Authorization: "Bearer test-key",
     });
   });
 });

--- a/runtime.ts
+++ b/runtime.ts
@@ -397,7 +397,9 @@ export async function resolveNanoGptRoutingMode(params: {
   try {
     return (await probeNanoGptSubscription(params.apiKey)) ? "subscription" : "paygo";
   } catch {
-    return "paygo";
+    // Favor subscription when auto-probing is ambiguous so temporary usage-endpoint
+    // failures do not silently downgrade subscription-capable requests into paygo.
+    return "subscription";
   }
 }
 


### PR DESCRIPTION
Improve the subscription routing behavior to favor subscription mode when the usage probe encounters errors, ensuring that subscription-capable requests are not downgraded to paygo.