### PR TITLE
Implement stream repair for malformed tool call arguments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import {
   resolveNanoGptDynamicModel,
   resolveNanoGptUsageAuth,
 } from "./runtime.js";
+import { wrapStreamWithToolCallRepair } from "./repair.js";
 import { createNanoGptWebSearchProvider } from "./web-search.js";
 import type {
   AnyAgentTool,
@@ -446,6 +447,12 @@ export default definePluginEntry({
         applyNanoGptNativeStreamingUsageCompat(providerConfig),
       resolveUsageAuth: async (ctx) => await resolveNanoGptUsageAuth(ctx),
       fetchUsageSnapshot: async (ctx) => await fetchNanoGptUsageSnapshot(ctx),
+      wrapStreamFn: (ctx) => {
+        if (ctx.streamFn) {
+          return wrapStreamWithToolCallRepair(ctx.streamFn, api.logger);
+        }
+        return undefined;
+      },
       classifyFailoverReason: (ctx) => {
         if (
           (ctx.errorMessage.includes("402") || ctx.errorMessage.includes("Insufficient balance")) &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "grammer": "^0.0.3",
-        "grammy": "^1.42.0"
+        "grammy": "^1.42.0",
+        "jsonrepair": "^3.13.3"
       },
       "devDependencies": {
         "@types/node": "^24.6.0",
@@ -7196,6 +7197,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.3.tgz",
+      "integrity": "sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/jszip": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "grammer": "^0.0.3",
-    "grammy": "^1.42.0"
+    "grammy": "^1.42.0",
+    "jsonrepair": "^3.13.3"
   }
 }

--- a/repair.test.ts
+++ b/repair.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from "vitest";
+import { wrapStreamWithToolCallRepair } from "./repair.js";
+import type { AssistantMessageEvent } from "@mariozechner/pi-ai";
+
+describe("wrapStreamWithToolCallRepair", () => {
+  it("should repair malformed tool call arguments", async () => {
+    const mockEvents: AssistantMessageEvent[] = [
+      {
+        type: "start",
+        partial: { 
+          role: "assistant", 
+          content: [], 
+          usage: { input: 0, output: 0, totalTokens: 0, cacheRead: 0, cacheWrite: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+          api: "openai-completions",
+          provider: "nanogpt",
+          model: "test-model",
+          timestamp: Date.now(),
+          stopReason: "stop"
+        } as any
+      },
+      {
+        type: "toolcall_start",
+        contentIndex: 0,
+        partial: {} as any
+      },
+      {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '{"location": "Tok',
+        partial: {} as any
+      },
+      {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: {
+          type: "toolCall",
+          id: "call_123",
+          name: "get_weather",
+          arguments: {} // Transport failed to parse
+        },
+        partial: {
+            content: [
+                {
+                    type: "toolCall",
+                    id: "call_123",
+                    name: "get_weather",
+                    arguments: {}
+                }
+            ]
+        } as any
+      },
+      {
+        type: "done",
+        reason: "toolUse",
+        message: {
+            content: [
+                {
+                    type: "toolCall",
+                    id: "call_123",
+                    name: "get_weather",
+                    arguments: {}
+                }
+            ]
+        } as any
+      }
+    ];
+
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      for (const event of mockEvents) {
+        yield event;
+      }
+    })());
+
+    const logger = {
+      warn: vi.fn(),
+      info: vi.fn(),
+    };
+
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const resultStream = await wrapped({ id: "test-model" } as any, {} as any, {} as any);
+
+    const receivedEvents: AssistantMessageEvent[] = [];
+    for await (const event of resultStream) {
+      receivedEvents.push(event);
+    }
+
+    const toolEndEvent = receivedEvents.find(e => e.type === "toolcall_end") as any;
+    expect(toolEndEvent).toBeDefined();
+    expect(toolEndEvent.toolCall.arguments).toEqual({ location: "Tok" }); 
+    // jsonrepair will turn {"location": "Tok into {"location": "Tok"}
+
+    const doneEvent = receivedEvents.find(e => e.type === "done") as any;
+    expect(doneEvent.message.content[0].arguments).toEqual({ location: "Tok" });
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("should repair markdown-wrapped JSON in tool call arguments", async () => {
+    const mockEvents: AssistantMessageEvent[] = [
+      {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '```json\n{"location": "Paris"}', // truncated and wrapped
+        partial: {} as any
+      },
+      {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: {
+          type: "toolCall",
+          id: "call_456",
+          name: "get_weather",
+          arguments: {}
+        },
+        partial: {} as any
+      }
+    ];
+
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      for (const event of mockEvents) {
+        yield event;
+      }
+    })());
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const resultStream = await wrapped({ id: "test-model" } as any, {} as any, {} as any);
+
+    const receivedEvents: AssistantMessageEvent[] = [];
+    for await (const event of resultStream) {
+      receivedEvents.push(event);
+    }
+
+    const toolEndEvent = receivedEvents.find(e => e.type === "toolcall_end") as any;
+    expect(toolEndEvent.toolCall.arguments).toEqual({ location: "Paris" });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/repair.ts
+++ b/repair.ts
@@ -1,0 +1,128 @@
+import { jsonrepair } from "jsonrepair";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  ToolCall,
+} from "@mariozechner/pi-ai";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+
+export type RepairLogger = {
+  warn: (message: string) => void;
+  info: (message: string) => void;
+};
+
+/**
+ * Wraps an OpenClaw model stream to automatically repair malformed JSON in tool call arguments.
+ * This is particularly useful for "thinking" models or models that may truncate output.
+ */
+export function wrapStreamWithToolCallRepair(
+  streamFn: StreamFn,
+  logger: RepairLogger,
+): StreamFn {
+  return async (...args) => {
+    const stream = await streamFn(...args);
+    const modelId = args[0]?.id || "unknown";
+
+    return (async function* () {
+      const toolCallArgBuffers = new Map<number, string>();
+
+      for await (const event of stream) {
+        if (event.type === "toolcall_delta") {
+          const current = toolCallArgBuffers.get(event.contentIndex) || "";
+          toolCallArgBuffers.set(event.contentIndex, current + event.delta);
+          yield event;
+        } else if (event.type === "toolcall_end") {
+          const rawArgs = toolCallArgBuffers.get(event.contentIndex);
+          if (rawArgs !== undefined) {
+            const repairedEvent = repairToolCallEndEvent(event, rawArgs, modelId, logger);
+            yield repairedEvent;
+          } else {
+            yield event;
+          }
+        } else if (event.type === "done") {
+          const repairedMessage = repairAssistantMessage(event.message, toolCallArgBuffers, modelId, logger);
+          yield { ...event, message: repairedMessage };
+        } else if (event.type === "error") {
+          const repairedError = repairAssistantMessage(event.error, toolCallArgBuffers, modelId, logger);
+          yield { ...event, error: repairedError };
+        } else {
+          yield event;
+        }
+      }
+    })() as any;
+  };
+}
+
+function repairToolCallEndEvent(
+  event: Extract<AssistantMessageEvent, { type: "toolcall_end" }>,
+  rawArgs: string,
+  modelId: string,
+  logger: RepairLogger,
+): AssistantMessageEvent {
+  try {
+    // Try standard parse first to see if it's already okay
+    JSON.parse(rawArgs);
+    return event;
+  } catch {
+    try {
+      const repairedJson = jsonrepair(rawArgs);
+      const parsed = JSON.parse(repairedJson);
+
+      logger.warn(
+        `[nanogpt] Repaired malformed tool call arguments from model ${modelId} for tool "${event.toolCall.name}"`,
+      );
+
+      return {
+        ...event,
+        toolCall: {
+          ...event.toolCall,
+          arguments: parsed,
+        },
+        partial: repairAssistantMessage(event.partial, new Map([[event.contentIndex, rawArgs]]), modelId, logger, true),
+      };
+    } catch (e) {
+      // If even jsonrepair fails, we just pass through and let the core handle the error
+      return event;
+    }
+  }
+}
+
+function repairAssistantMessage(
+  message: AssistantMessage,
+  buffers: Map<number, string>,
+  modelId: string,
+  logger: RepairLogger,
+  silent = false,
+): AssistantMessage {
+  if (!message.content) return message;
+
+  let changed = false;
+  const newContent = message.content.map((block, index) => {
+    if (block.type === "toolCall") {
+      const rawArgs = buffers.get(index);
+      if (rawArgs === undefined) return block;
+
+      try {
+        JSON.parse(rawArgs);
+        return block;
+      } catch {
+        try {
+          const repairedJson = jsonrepair(rawArgs);
+          const parsed = JSON.parse(repairedJson);
+          if (!silent) {
+            logger.warn(
+              `[nanogpt] Repaired malformed tool call arguments in final message from model ${modelId} for tool "${block.name}"`,
+            );
+          }
+          changed = true;
+          return { ...block, arguments: parsed };
+        } catch {
+          return block;
+        }
+      }
+    }
+    return block;
+  });
+
+  return changed ? { ...message, content: newContent as any } : message;
+}


### PR DESCRIPTION
Introduce functionality to automatically repair malformed JSON in tool call arguments during streaming. This enhancement includes tests to ensure proper handling of various malformed inputs. Additionally, the `jsonrepair` library has been added as a dependency to facilitate the repair process.