### PR TITLE
Enhance installation instructions and add package-files test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 .env
+dist/

--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ it does not reconstruct token counts from them.
 
 ## Install
 
-### Recommended: install from a clean build directory
+### Clean install from source (recommended)
 
-This mirrors a local OpenClaw checkout: run from a clean built surface under
-`dist/` instead of pointing the installer at the whole working tree.
+This is the most reliable local install path. Clone the repo, install
+dependencies, build a clean plugin surface under `dist/`, and install from
+`dist/package` instead of pointing OpenClaw at the whole working tree.
 
 ```bash
+cd ~/Github
+git clone git@github.com:deadronos/nanogpt-provider-openclaw.git
+cd nanogpt-provider-openclaw
+npm install
 npm run build
 openclaw plugins install ./dist/package
 openclaw gateway restart
@@ -58,12 +63,12 @@ openclaw plugins install ./dist/*.tgz
 openclaw gateway restart
 ```
 
-### Local install from a clean checkout
+### Direct install from a raw checkout
 
 This only works if the checkout is small enough for OpenClaw's manifest scan.
 If you've already run `pnpm install` in the repo root, the local `node_modules/`
 tree can push the scan past OpenClaw's directory cap. In that case, use the
-build-directory flow below instead.
+recommended build flow above instead.
 
 ```bash
 cd ~/Github

--- a/README.md
+++ b/README.md
@@ -36,17 +36,14 @@ it does not reconstruct token counts from them.
 
 ## Install
 
-### Local install from a clean checkout
+### Recommended: install from a clean build directory
 
-This only works if the checkout is small enough for OpenClaw's manifest scan.
-If you've already run `pnpm install` in the repo root, the local `node_modules/`
-tree can push the scan past OpenClaw's directory cap. In that case, use the
-tarball flow below instead.
+This mirrors a local OpenClaw checkout: run from a clean built surface under
+`dist/` instead of pointing the installer at the whole working tree.
 
 ```bash
-cd ~/Github
-git clone git@github.com:deadronos/nanogpt-provider-openclaw.git
-openclaw plugins install ~/Github/nanogpt-provider-openclaw
+npm run build
+openclaw plugins install ./dist/package
 openclaw gateway restart
 ```
 
@@ -56,8 +53,22 @@ This is the safest local-install path because OpenClaw scans the packed plugin
 surface rather than the whole working tree.
 
 ```bash
-npm run build
+npm run build:tgz
 openclaw plugins install ./dist/*.tgz
+openclaw gateway restart
+```
+
+### Local install from a clean checkout
+
+This only works if the checkout is small enough for OpenClaw's manifest scan.
+If you've already run `pnpm install` in the repo root, the local `node_modules/`
+tree can push the scan past OpenClaw's directory cap. In that case, use the
+build-directory flow below instead.
+
+```bash
+cd ~/Github
+git clone git@github.com:deadronos/nanogpt-provider-openclaw.git
+openclaw plugins install ~/Github/nanogpt-provider-openclaw
 openclaw gateway restart
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ it does not reconstruct token counts from them.
 
 ## Install
 
-### Local install from a checkout
+### Local install from a clean checkout
 
-This is the most practical path right now.
+This only works if the checkout is small enough for OpenClaw's manifest scan.
+If you've already run `pnpm install` in the repo root, the local `node_modules/`
+tree can push the scan past OpenClaw's directory cap. In that case, use the
+tarball flow below instead.
 
 ```bash
 cd ~/Github
@@ -49,9 +52,12 @@ openclaw gateway restart
 
 ### Install from a tarball
 
+This is the safest local-install path because OpenClaw scans the packed plugin
+surface rather than the whole working tree.
+
 ```bash
-npm pack
-openclaw plugins install ./deadronos-openclaw-nanogpt-provider-0.1.0.tgz
+npm run build
+openclaw plugins install ./dist/*.tgz
 openclaw gateway restart
 ```
 

--- a/package-files.test.ts
+++ b/package-files.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type PackageManifest = {
+  files?: unknown;
+};
+
+const repoRoot = dirname(fileURLToPath(import.meta.url));
+
+function readPackageManifest(): PackageManifest {
+  return JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as PackageManifest;
+}
+
+function resolveFileEntries(manifest: PackageManifest): string[] {
+  if (!Array.isArray(manifest.files)) {
+    return [];
+  }
+
+  return manifest.files.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
+}
+
+describe("package manifest files", () => {
+  it("keeps every runtime entrypoint in the published package surface", () => {
+    const manifest = readPackageManifest();
+    const files = resolveFileEntries(manifest);
+
+    expect(files).toEqual(
+      expect.arrayContaining([
+        "index.ts",
+        "api.ts",
+        "models.ts",
+        "repair.ts",
+        "runtime.ts",
+        "provider-catalog.ts",
+        "provider-discovery.ts",
+        "image-generation-provider.ts",
+        "web-search.ts",
+        "onboard.ts",
+        "openclaw.plugin.json",
+        "README.md",
+        "LICENSE.md",
+      ]),
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "build": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true })\" && npm run typecheck && npm pack --pack-destination ./dist"
+    "build": "npm run typecheck && node ./scripts/stage-package-dir.mjs",
+    "build:tgz": "npm run build && npm pack ./dist/package --pack-destination ./dist"
   },
   "peerDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "index.ts",
     "api.ts",
     "models.ts",
+    "repair.ts",
     "runtime.ts",
     "provider-catalog.ts",
     "provider-discovery.ts",
@@ -36,7 +37,8 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true })\" && npm run typecheck && npm pack --pack-destination ./dist"
   },
   "peerDependencies": {
     "openclaw": ">=2026.3.24-beta.2"

--- a/scripts/stage-package-dir.mjs
+++ b/scripts/stage-package-dir.mjs
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+function isPathInside(rootPath, targetPath) {
+  const relativePath = path.relative(rootPath, targetPath);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+  );
+}
+
+export function readPackageManifest(repoRoot) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+}
+
+function normalizeSurfaceEntry(entry) {
+  return typeof entry === "string" ? entry.trim() : "";
+}
+
+export function resolvePackageSurfaceEntries(manifest) {
+  const explicitEntries = Array.isArray(manifest.files)
+    ? manifest.files.map(normalizeSurfaceEntry).filter(Boolean)
+    : [];
+
+  return ["package.json", ...explicitEntries];
+}
+
+function copySurfaceEntry(sourcePath, targetPath) {
+  const sourceStats = fs.statSync(sourcePath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+
+  if (sourceStats.isDirectory()) {
+    fs.cpSync(sourcePath, targetPath, { recursive: true, dereference: true });
+    return;
+  }
+
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+export function stagePackageDir(params = {}) {
+  const repoRoot = params.repoRoot ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const outputDir = params.outputDir ?? path.join(repoRoot, "dist", "package");
+  const manifest = params.manifest ?? readPackageManifest(repoRoot);
+  const surfaceEntries = params.surfaceEntries ?? resolvePackageSurfaceEntries(manifest);
+
+  fs.rmSync(outputDir, { recursive: true, force: true });
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  for (const entry of surfaceEntries) {
+    const sourcePath = path.resolve(repoRoot, entry);
+    if (!isPathInside(repoRoot, sourcePath)) {
+      throw new Error(`Package surface entry escapes repository root: ${entry}`);
+    }
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(`Package surface entry not found: ${entry}`);
+    }
+    if (isPathInside(sourcePath, outputDir)) {
+      throw new Error(`Package surface entry overlaps build output: ${entry}`);
+    }
+
+    const targetPath = path.join(outputDir, entry);
+    copySurfaceEntry(sourcePath, targetPath);
+  }
+
+  return outputDir;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.stdout.write(`${stagePackageDir()}\n`);
+}

--- a/stage-package-dir.test.ts
+++ b/stage-package-dir.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+// @ts-expect-error Test imports a plain .mjs build script under a TS-only repo config.
+import { resolvePackageSurfaceEntries, stagePackageDir } from "./scripts/stage-package-dir.mjs";
+
+const tempPaths: string[] = [];
+
+function makeTempDir() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nanogpt-stage-package-dir-"));
+  tempPaths.push(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  while (tempPaths.length > 0) {
+    const tempPath = tempPaths.pop();
+    if (!tempPath) {
+      continue;
+    }
+    fs.rmSync(tempPath, { recursive: true, force: true });
+  }
+});
+
+describe("stage package dir", () => {
+  it("includes package.json plus every declared package surface entry", () => {
+    expect(
+      resolvePackageSurfaceEntries({
+        files: ["index.ts", "README.md", "nested/config.json"],
+      }),
+    ).toEqual(["package.json", "index.ts", "README.md", "nested/config.json"]);
+  });
+
+  it("stages a clean install directory from the declared package surface", () => {
+    const repoRoot = makeTempDir();
+    const outputDir = path.join(repoRoot, "dist", "package");
+    const manifest = {
+      name: "example-plugin",
+      version: "1.0.0",
+      files: ["index.ts", "README.md", "nested/config.json"],
+    };
+
+    fs.writeFileSync(path.join(repoRoot, "package.json"), JSON.stringify(manifest, null, 2));
+    fs.writeFileSync(path.join(repoRoot, "index.ts"), "export const plugin = true;\n");
+    fs.writeFileSync(path.join(repoRoot, "README.md"), "# Example\n");
+    fs.mkdirSync(path.join(repoRoot, "nested"), { recursive: true });
+    fs.writeFileSync(path.join(repoRoot, "nested", "config.json"), '{"ok":true}\n');
+
+    const stagedDir = stagePackageDir({ repoRoot, outputDir });
+
+    expect(stagedDir).toBe(outputDir);
+    expect(fs.readFileSync(path.join(outputDir, "package.json"), "utf8")).toContain(
+      '"example-plugin"',
+    );
+    expect(fs.readFileSync(path.join(outputDir, "index.ts"), "utf8")).toContain(
+      "plugin = true",
+    );
+    expect(fs.readFileSync(path.join(outputDir, "README.md"), "utf8")).toContain("# Example");
+    expect(fs.readFileSync(path.join(outputDir, "nested", "config.json"), "utf8")).toContain(
+      '"ok":true',
+    );
+    expect(fs.existsSync(path.join(outputDir, "node_modules"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Improve the README with clearer installation instructions for clean builds and add a staging script for the package directory. Introduce a test to ensure all runtime entrypoints are included in the published package surface. Update the .gitignore to exclude the `dist/` directory.