### PR TITLE
Enhance stream wrapping for tool call argument repair

### DIFF
--- a/repair.test.ts
+++ b/repair.test.ts
@@ -135,4 +135,109 @@ describe("wrapStreamWithToolCallRepair", () => {
     expect(toolEndEvent.toolCall.arguments).toEqual({ location: "Paris" });
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it("preserves bind-compatible stream methods for downstream wrappers", async () => {
+    const mockEvents: AssistantMessageEvent[] = [
+      {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '{"location":"Berlin',
+        partial: {} as any,
+      },
+      {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: {
+          type: "toolCall",
+          id: "call_789",
+          name: "get_weather",
+          arguments: {},
+        },
+        partial: {
+          content: [
+            {
+              type: "toolCall",
+              id: "call_789",
+              name: "get_weather",
+              arguments: {},
+            },
+          ],
+        } as any,
+      },
+      {
+        type: "done",
+        reason: "toolUse",
+        message: {
+          content: [
+            {
+              type: "toolCall",
+              id: "call_789",
+              name: "get_weather",
+              arguments: {},
+            },
+          ],
+        } as any,
+      },
+    ];
+
+    const originalStream = {
+      async result() {
+        return {
+          content: [
+            {
+              type: "toolCall",
+              id: "call_789",
+              name: "get_weather",
+              arguments: {},
+            },
+          ],
+        } as any;
+      },
+      [Symbol.asyncIterator]() {
+        let index = 0;
+        return {
+          next: async () => {
+            if (index >= mockEvents.length) {
+              return { done: true as const, value: undefined };
+            }
+            const value = mockEvents[index++];
+            return { done: false as const, value };
+          },
+          async return(value?: unknown) {
+            return { done: true as const, value };
+          },
+          async throw(error?: unknown) {
+            throw error;
+          },
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+        };
+      },
+    };
+
+    const mockStreamFn = vi.fn().mockResolvedValue(originalStream);
+    const logger = { warn: vi.fn(), info: vi.fn() };
+
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const wrappedStream = await wrapped({ id: "test-model" } as any, {} as any, {} as any);
+
+    expect(typeof (wrappedStream as any).result).toBe("function");
+    expect(typeof (wrappedStream as any)[Symbol.asyncIterator]).toBe("function");
+
+    const boundResult = (wrappedStream as any).result.bind(wrappedStream);
+    const boundAsyncIterator = (wrappedStream as any)[Symbol.asyncIterator].bind(wrappedStream);
+
+    const iterator = boundAsyncIterator();
+    const receivedEvents: AssistantMessageEvent[] = [];
+    for await (const event of iterator as AsyncIterable<AssistantMessageEvent>) {
+      receivedEvents.push(event);
+    }
+
+    const repairedEndEvent = receivedEvents.find((event) => event.type === "toolcall_end") as any;
+    expect(repairedEndEvent.toolCall.arguments).toEqual({ location: "Berlin" });
+
+    const resultMessage = await boundResult();
+    expect(resultMessage.content[0].arguments).toEqual({ location: "Berlin" });
+  });
 });

--- a/repair.ts
+++ b/repair.ts
@@ -23,34 +23,91 @@ export function wrapStreamWithToolCallRepair(
     const stream = await streamFn(...args);
     const modelId = args[0]?.id || "unknown";
 
-    return (async function* () {
-      const toolCallArgBuffers = new Map<number, string>();
-
-      for await (const event of stream) {
-        if (event.type === "toolcall_delta") {
-          const current = toolCallArgBuffers.get(event.contentIndex) || "";
-          toolCallArgBuffers.set(event.contentIndex, current + event.delta);
-          yield event;
-        } else if (event.type === "toolcall_end") {
-          const rawArgs = toolCallArgBuffers.get(event.contentIndex);
-          if (rawArgs !== undefined) {
-            const repairedEvent = repairToolCallEndEvent(event, rawArgs, modelId, logger);
-            yield repairedEvent;
-          } else {
-            yield event;
-          }
-        } else if (event.type === "done") {
-          const repairedMessage = repairAssistantMessage(event.message, toolCallArgBuffers, modelId, logger);
-          yield { ...event, message: repairedMessage };
-        } else if (event.type === "error") {
-          const repairedError = repairAssistantMessage(event.error, toolCallArgBuffers, modelId, logger);
-          yield { ...event, error: repairedError };
-        } else {
-          yield event;
-        }
-      }
-    })() as any;
+    return wrapToolCallRepairStream(stream, modelId, logger) as any;
   };
+}
+
+function wrapToolCallRepairStream<TStream extends AsyncIterable<AssistantMessageEvent>>(
+  stream: TStream,
+  modelId: string,
+  logger: RepairLogger,
+): TStream {
+  const toolCallArgBuffers = new Map<number, string>();
+  const wrappedStream = stream as TStream & {
+    result?: () => Promise<AssistantMessage>;
+    [Symbol.asyncIterator]: () => AsyncIterator<AssistantMessageEvent>;
+  };
+
+  const originalAsyncIterator = wrappedStream[Symbol.asyncIterator].bind(wrappedStream);
+  wrappedStream[Symbol.asyncIterator] = function () {
+    const iterator = originalAsyncIterator();
+    return {
+      async next() {
+        const result = await iterator.next();
+        if (result.done) {
+          return result;
+        }
+
+        return {
+          done: false as const,
+          value: repairAssistantMessageEvent(result.value, toolCallArgBuffers, modelId, logger),
+        };
+      },
+      async return(value?: unknown) {
+        return iterator.return?.(value) ?? { done: true as const, value: undefined };
+      },
+      async throw(error?: unknown) {
+        return iterator.throw?.(error) ?? Promise.reject(error);
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+  };
+
+  if (typeof wrappedStream.result === "function") {
+    const originalResult = wrappedStream.result.bind(wrappedStream);
+    wrappedStream.result = async () => {
+      const message = await originalResult();
+      return repairAssistantMessage(message, toolCallArgBuffers, modelId, logger);
+    };
+  }
+
+  return wrappedStream;
+}
+
+function repairAssistantMessageEvent(
+  event: AssistantMessageEvent,
+  toolCallArgBuffers: Map<number, string>,
+  modelId: string,
+  logger: RepairLogger,
+): AssistantMessageEvent {
+  if (event.type === "toolcall_delta") {
+    const current = toolCallArgBuffers.get(event.contentIndex) || "";
+    toolCallArgBuffers.set(event.contentIndex, current + event.delta);
+    return event;
+  }
+
+  if (event.type === "toolcall_end") {
+    const rawArgs = toolCallArgBuffers.get(event.contentIndex);
+    return rawArgs !== undefined ? repairToolCallEndEvent(event, rawArgs, modelId, logger) : event;
+  }
+
+  if (event.type === "done") {
+    return {
+      ...event,
+      message: repairAssistantMessage(event.message, toolCallArgBuffers, modelId, logger),
+    };
+  }
+
+  if (event.type === "error") {
+    return {
+      ...event,
+      error: repairAssistantMessage(event.error, toolCallArgBuffers, modelId, logger),
+    };
+  }
+
+  return event;
 }
 
 function repairToolCallEndEvent(


### PR DESCRIPTION
Improve handling of malformed tool call arguments and enhance async iterator functionality within the stream wrapping process. This update ensures better preservation of bind-compatible stream methods for downstream wrappers.