### PR TITLE
Add tool call argument repair for Kimi-style models

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -26,6 +26,13 @@ describe("nanogpt plugin entry", () => {
           models?: Array<Record<string, unknown>>;
         };
       }) => unknown;
+      wrapStreamFn?: (ctx: {
+        streamFn?: (...args: unknown[]) => unknown;
+        modelId: string;
+        model?: {
+          id?: string;
+        };
+      }) => unknown;
       normalizeToolSchemas?: (ctx: {
         provider: string;
         modelId?: string;
@@ -214,6 +221,28 @@ describe("nanogpt plugin entry", () => {
       },
     });
     expect(responsesApiResult).toBeNull();
+  });
+
+  it("only applies tool-call JSON repair to Kimi-style models", () => {
+    const provider = getRegisteredProvider();
+    expect(provider.wrapStreamFn).toEqual(expect.any(Function));
+
+    const baseStreamFn = vi.fn();
+
+    const mistralStreamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      modelId: "mistralai/mistral-large-3-675b-instruct-2512",
+      model: { id: "mistralai/mistral-large-3-675b-instruct-2512" },
+    });
+    expect(mistralStreamFn).toBe(baseStreamFn);
+
+    const kimiStreamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      modelId: "moonshotai/kimi-k2.5:thinking",
+      model: { id: "moonshotai/kimi-k2.5:thinking" },
+    });
+    expect(kimiStreamFn).toEqual(expect.any(Function));
+    expect(kimiStreamFn).not.toBe(baseStreamFn);
   });
 
   it("leaves web_fetch untouched for all models since aliasing is disabled", () => {

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,10 @@ import {
   resolveNanoGptDynamicModel,
   resolveNanoGptUsageAuth,
 } from "./runtime.js";
-import { wrapStreamWithToolCallRepair } from "./repair.js";
+import {
+  shouldRepairNanoGptToolCallArguments,
+  wrapStreamWithToolCallRepair,
+} from "./repair.js";
 import { createNanoGptWebSearchProvider } from "./web-search.js";
 import type {
   AnyAgentTool,
@@ -449,6 +452,11 @@ export default definePluginEntry({
       fetchUsageSnapshot: async (ctx) => await fetchNanoGptUsageSnapshot(ctx),
       wrapStreamFn: (ctx) => {
         if (ctx.streamFn) {
+          const repairModelId =
+            typeof ctx.model?.id === "string" && ctx.model.id.trim() ? ctx.model.id : ctx.modelId;
+          if (!shouldRepairNanoGptToolCallArguments(repairModelId)) {
+            return ctx.streamFn;
+          }
           return wrapStreamWithToolCallRepair(ctx.streamFn, api.logger);
         }
         return undefined;

--- a/repair.test.ts
+++ b/repair.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
-import { wrapStreamWithToolCallRepair } from "./repair.js";
+import {
+  shouldRepairNanoGptToolCallArguments,
+  wrapStreamWithToolCallRepair,
+} from "./repair.js";
 import type { AssistantMessageEvent } from "@mariozechner/pi-ai";
+
+describe("shouldRepairNanoGptToolCallArguments", () => {
+  it("only enables repair for Kimi-style NanoGPT model ids", () => {
+    expect(shouldRepairNanoGptToolCallArguments("moonshotai/kimi-k2.5")).toBe(true);
+    expect(shouldRepairNanoGptToolCallArguments("moonshotai/kimi-k2.5:thinking")).toBe(true);
+    expect(shouldRepairNanoGptToolCallArguments("nanogpt/moonshotai/kimi-k2.5:thinking")).toBe(true);
+    expect(shouldRepairNanoGptToolCallArguments("mistralai/mistral-large-3-675b-instruct-2512")).toBe(false);
+    expect(shouldRepairNanoGptToolCallArguments(undefined)).toBe(false);
+  });
+});
 
 describe("wrapStreamWithToolCallRepair", () => {
   it("should repair malformed tool call arguments", async () => {

--- a/repair.ts
+++ b/repair.ts
@@ -2,7 +2,6 @@ import { jsonrepair } from "jsonrepair";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
-  ToolCall,
 } from "@mariozechner/pi-ai";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 
@@ -10,6 +9,19 @@ export type RepairLogger = {
   warn: (message: string) => void;
   info: (message: string) => void;
 };
+
+function normalizeNanoGptRepairModelId(modelId: string): string {
+  const normalized = modelId.trim().toLowerCase();
+  return normalized.startsWith("nanogpt/") ? normalized.slice("nanogpt/".length) : normalized;
+}
+
+export function shouldRepairNanoGptToolCallArguments(modelId?: string): boolean {
+  if (!modelId?.trim()) {
+    return false;
+  }
+  const normalized = normalizeNanoGptRepairModelId(modelId);
+  return normalized.startsWith("moonshotai/kimi");
+}
 
 /**
  * Wraps an OpenClaw model stream to automatically repair malformed JSON in tool call arguments.


### PR DESCRIPTION
Introduce functionality to repair tool call arguments specifically for Kimi-style models and enhance the stream wrapping process. This update ensures that only Kimi-style models undergo argument repair while maintaining the original behavior for other models.