### PR TITLE
Enhance tool-call reliability and debugging features

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,15 @@ For example:
 - `requestApi: "auto"` defaults to Completions for broader model compatibility; set to `"responses"` explicitly if your models support the Responses API.
 - Completions-mode models are still marked with streaming usage compatibility so
   OpenClaw requests `stream_options.include_usage` automatically.
-- `moonshotai/kimi-k2.5` and `moonshotai/kimi-k2.5:thinking` keep tool support
-  enabled, but the plugin aliases OpenClaw's `web_fetch` tool to
-  `fetch_web_page` for those two model ids. Live NanoGPT checks showed the exact
-  `web_fetch` tool name could trigger billing-limit/timeout failures on the
-  post-tool follow-up, while the aliased tool name completed normally.
+- `moonshotai/kimi*` models keep tool support enabled and get extra reliability
+  handling in the stream wrapper:
+  - malformed tool-call argument JSON repair
+  - one-shot retry for tool-enabled turns that end with no visible content or
+    recognized tool call
+  - best-effort salvage of structured tool payloads wrapped as assistant text
+- The plugin does **not** currently alias `web_fetch` to `fetch_web_page` on
+  `main`; that earlier experiment remains documented in repo history, but the
+  alias is currently disabled in code.
 - `provider` adds NanoGPT's `X-Provider` override header for text requests.
 - if `provider` is set while the request would otherwise use subscription
   routing, the plugin also sets `X-Billing-Mode: paygo`
@@ -306,6 +310,15 @@ expose that data directly.
 npm test
 npm run typecheck
 ```
+
+### Tool-call reliability debugging
+
+Set `NANOGPT_DEBUG_TOOL_RELIABILITY=1` before running OpenClaw to emit
+structured info logs for Kimi-targeted repair, salvage, and retry decisions.
+
+The debug logs are intended for diagnosing tool-call failures and include fields
+such as the model id, request API, repair stage, retry attempt, and whether a
+structured tool payload was salvaged from assistant text.
 
 ### Publish workflow
 

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -4,6 +4,11 @@
 **Reviewer:** Claude Code
 **Scope:** Full project review — index.ts, runtime.ts, models.ts, api.ts, provider-catalog.ts, web-search.ts, image-generation-provider.ts, onboard.ts, openclaw.plugin.json
 
+> Status refresh (2026-04-17): this document is a historical review snapshot.
+> Some observations below were true at the time but are no longer current on
+> `main`. Prefer the newer dated audits in `docs/` for current capability and
+> lifecycle coverage.
+
 ---
 
 ## Overview
@@ -56,9 +61,11 @@ Hardcoded fallback models have `cost: { input: 0, output: 0, ...}`. This means i
 
 All tests mock `fetch` globally. There are no tests against a real NanoGPT API endpoint. This is acceptable for a plugin but worth noting as a gap.
 
-### `openclaw.plugin.json` — `webSearch` config not in schema
+### `openclaw.plugin.json` — `webSearch` config not in schema (resolved on `main`)
 
-The README documents `plugins.entries.nanogpt.config.webSearch.apiKey` but the plugin schema only validates the top-level fields (`routingMode`, `catalogSource`, `requestApi`, `provider`). The `webSearch` sub-config is accessed via SDK helpers but is not declared in the schema.
+This issue has since been fixed. `openclaw.plugin.json` now declares the
+`webSearch.apiKey` config schema entry, so this finding is only preserved as a
+historical note from the original review.
 
 ### `__testing` export in `web-search.ts:205-208`
 
@@ -69,7 +76,7 @@ Exported for tests but has no `export type`. Standard pattern in this codebase t
 ## Summary
 
 | Area | Status |
-|------|--------|
+| ---- | ------ |
 | Tests | 23/23 passing |
 | TypeScript | Clean (`tsc --noEmit`) |
 | Architecture | Well-separated |

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,19 +12,19 @@ Actionable follow-up work based on:
 
 ### Docs and behavior alignment
 
-- [ ] Resolve the Kimi `web_fetch` aliasing mismatch.
+- [x] Resolve the Kimi `web_fetch` aliasing mismatch.
   - `README.md` still says Kimi aliases `web_fetch` to `fetch_web_page`.
   - `models.ts` currently keeps aliasing disabled via an empty alias-model set.
   - Pick one truth:
     - re-enable the alias with fresh tests and evidence, or
     - remove the README claim and document the current disabled state.
-- [ ] Refresh or trim stale findings docs.
+- [x] Refresh or trim stale findings docs.
   - `docs/findings.md` contains at least some observations that are no longer true on `main`.
   - Re-scan and either update it or archive old findings into dated docs.
 
 ### Reliability observability
 
-- [ ] Add structured, opt-in debug artifacts for tool-call reliability failures.
+- [x] Add structured, opt-in debug artifacts for tool-call reliability failures.
   - Capture at least:
     - model id
     - request API (`completions` vs `responses`)
@@ -36,12 +36,12 @@ Actionable follow-up work based on:
   - Likely files:
     - `repair.ts`
     - `index.ts`
-- [ ] Document the debug mode once added.
+- [x] Document the debug mode once added.
   - Update `README.md` with the intended troubleshooting flow.
 
 ### Reliability test coverage
 
-- [ ] Expand the failure-taxonomy tests beyond malformed JSON arguments.
+- [x] Expand the failure-taxonomy tests beyond malformed JSON arguments.
   - Add targeted cases for:
     - empty tool-enabled turns
     - prose-wrapped tool payloads
@@ -62,13 +62,13 @@ Actionable follow-up work based on:
     - `createStreamFn`
     - `prepareExtraParams`
     - `wrapStreamFn`
-- [ ] Add a one-shot retry for invalid empty tool turns.
+- [x] Add a one-shot retry for invalid empty tool turns.
   - Scope it narrowly:
     - tool-enabled turns only
     - known-problem model families only
     - exactly one retry
   - This should be treated as a protocol-recovery step, not a general retry policy.
-- [ ] Add broader salvage parsing for near-valid tool payloads.
+- [x] Add broader salvage parsing for near-valid tool payloads.
   - Accept or normalize more than just malformed argument JSON when practical.
   - Focus on cases where the model output is structurally obvious but not in the exact downstream tool-call shape.
 - [ ] Decide whether raw-response recovery belongs in-process or behind a sidecar/proxy mode.
@@ -152,10 +152,10 @@ Actionable follow-up work based on:
 
 ## Suggested execution order
 
-1. [ ] Fix README/code drift and refresh stale findings docs.
-2. [ ] Add structured debug artifacts for reliability work.
-3. [ ] Expand reliability test coverage.
-4. [ ] Prototype one-shot invalid-empty retry and broader salvage parsing.
+1. [x] Fix README/code drift and refresh stale findings docs.
+2. [x] Add structured debug artifacts for reliability work.
+3. [x] Expand reliability test coverage.
+4. [x] Prototype one-shot invalid-empty retry and broader salvage parsing.
 5. [ ] Decide whether a stronger in-process hook or a sidecar/proxy path is the right long-term reliability architecture.
 6. [ ] Add embeddings.
 7. [ ] Expand web search.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,186 @@
+# TODO
+
+Actionable follow-up work based on:
+
+- [`nanoproxy-openclaw-tool-reliability-report-2026-04-16.md`](./nanoproxy-openclaw-tool-reliability-report-2026-04-16.md)
+- [`openclaw-provider-model-request-lifecycle-hooks-2026-04-16.md`](./openclaw-provider-model-request-lifecycle-hooks-2026-04-16.md)
+- [`nanogpt-api-surface-coverage-audit-2026-04-14.md`](./nanogpt-api-surface-coverage-audit-2026-04-14.md)
+- [`openclaw-vs-nanogpt-provider-capability-coverage-2026-04-14.md`](./openclaw-vs-nanogpt-provider-capability-coverage-2026-04-14.md)
+- [`nanogpt-audio-openclaw-fit-and-pricing-2026-04-14.md`](./nanogpt-audio-openclaw-fit-and-pricing-2026-04-14.md)
+
+## High-priority cleanup
+
+### Docs and behavior alignment
+
+- [ ] Resolve the Kimi `web_fetch` aliasing mismatch.
+  - `README.md` still says Kimi aliases `web_fetch` to `fetch_web_page`.
+  - `models.ts` currently keeps aliasing disabled via an empty alias-model set.
+  - Pick one truth:
+    - re-enable the alias with fresh tests and evidence, or
+    - remove the README claim and document the current disabled state.
+- [ ] Refresh or trim stale findings docs.
+  - `docs/findings.md` contains at least some observations that are no longer true on `main`.
+  - Re-scan and either update it or archive old findings into dated docs.
+
+### Reliability observability
+
+- [ ] Add structured, opt-in debug artifacts for tool-call reliability failures.
+  - Capture at least:
+    - model id
+    - request API (`completions` vs `responses`)
+    - tool name
+    - raw argument length
+    - repair stage (`toolcall_end` vs final message)
+    - whether repair succeeded or failed
+    - whether the turn ended with no recognized tool call
+  - Likely files:
+    - `repair.ts`
+    - `index.ts`
+- [ ] Document the debug mode once added.
+  - Update `README.md` with the intended troubleshooting flow.
+
+### Reliability test coverage
+
+- [ ] Expand the failure-taxonomy tests beyond malformed JSON arguments.
+  - Add targeted cases for:
+    - empty tool-enabled turns
+    - prose-wrapped tool payloads
+    - fenced JSON tool payloads
+    - flattened tool arguments
+    - mismatches between streamed tool-call events and the final assistant message
+  - Likely files:
+    - `repair.test.ts`
+    - possibly a new reliability-focused test file if the matrix grows too large
+
+## Next reliability improvements
+
+### Move reliability earlier in the lifecycle
+
+- [ ] Prototype a stronger reliability seam than argument-only repair.
+  - Current behavior is mainly `wrapStreamFn` + `jsonrepair(...)` after tool-call parsing already happened.
+  - The OpenClaw lifecycle review suggests the better seams are:
+    - `createStreamFn`
+    - `prepareExtraParams`
+    - `wrapStreamFn`
+- [ ] Add a one-shot retry for invalid empty tool turns.
+  - Scope it narrowly:
+    - tool-enabled turns only
+    - known-problem model families only
+    - exactly one retry
+  - This should be treated as a protocol-recovery step, not a general retry policy.
+- [ ] Add broader salvage parsing for near-valid tool payloads.
+  - Accept or normalize more than just malformed argument JSON when practical.
+  - Focus on cases where the model output is structurally obvious but not in the exact downstream tool-call shape.
+- [ ] Decide whether raw-response recovery belongs in-process or behind a sidecar/proxy mode.
+  - If OpenClaw hook access is too late for full salvage, evaluate a proxy/sidecar option instead of overloading the current wrapper path.
+
+### Reliability profiles instead of one-off model hacks
+
+- [ ] Introduce model-scoped reliability profiles.
+  - Example profile shapes:
+    - native only
+    - native + argument repair
+    - native-first + one retry
+    - bridge fallback
+    - bridge-always for known-problem models
+  - Likely home:
+    - `models.ts`
+    - `index.ts`
+    - a new reliability helper module if needed
+
+### Canonicalization and compatibility helpers
+
+- [ ] Replace one-off aliasing with a broader canonicalization strategy if tool-name drift becomes a recurring issue.
+  - Tool-name aliasing should be documented, tested, and kept consistent with the README.
+  - Only do this after the transport-level reliability work is clearer.
+
+## Feature expansion
+
+### Embeddings
+
+- [ ] Add NanoGPT embeddings support.
+  - This is still the strongest next missing OpenClaw capability.
+  - Best fit:
+    - implement the OpenClaw embeddings provider surface
+    - document embeddings as paygo-first unless NanoGPT clearly supports subscription-backed embeddings
+
+### Web search expansion
+
+- [ ] Deepen the existing NanoGPT web-search provider.
+  - Current implementation is intentionally narrow and hard-codes:
+    - `provider: "linkup"`
+    - `depth: "standard"`
+    - `outputType: "searchResults"`
+  - Add support for a richer subset where OpenClaw can consume it cleanly, such as:
+    - provider selection
+    - depth selection
+    - alternate output types
+    - structured output / schema
+    - sourced answers
+    - date filters
+  - Likely file:
+    - `web-search.ts`
+
+### Image generation expansion
+
+- [ ] Expand image generation beyond the curated subset.
+  - Candidate follow-ups:
+    - official image-model discovery
+    - more request knobs
+    - broader response modes
+    - mask/inpainting support where useful
+  - Likely file:
+    - `image-generation-provider.ts`
+
+### Optional audio expansion
+
+- [ ] If audio is added, do STT first.
+  - Best first fit:
+    - `POST /api/v1/audio/transcriptions`
+  - Treat it as paygo-first in docs and UX.
+- [ ] Add TTS second if audio becomes a real product goal.
+  - Best first fit:
+    - `POST /api/v1/audio/speech`
+
+## Lower-priority or deferred work
+
+- [ ] Defer stored/background Responses lifecycle helpers unless a real use case appears.
+- [ ] Defer `prepareRuntimeAuth` work unless NanoGPT adds a runtime auth exchange flow that needs it.
+- [ ] Defer standalone web-fetch/scrape integration unless it becomes important to actual workflows.
+- [ ] Defer video generation, realtime voice, realtime transcription, and music generation.
+- [ ] Defer NanoGPT account, balance, team, referral, payment, and TEE surfaces unless the plugin scope broadens significantly.
+
+## Suggested execution order
+
+1. [ ] Fix README/code drift and refresh stale findings docs.
+2. [ ] Add structured debug artifacts for reliability work.
+3. [ ] Expand reliability test coverage.
+4. [ ] Prototype one-shot invalid-empty retry and broader salvage parsing.
+5. [ ] Decide whether a stronger in-process hook or a sidecar/proxy path is the right long-term reliability architecture.
+6. [ ] Add embeddings.
+7. [ ] Expand web search.
+8. [ ] Deepen image generation.
+9. [ ] Optionally add STT, then TTS.
+
+## Likely owning files by theme
+
+- Reliability and hook wiring:
+  - `index.ts`
+  - `repair.ts`
+  - `models.ts`
+- Text/catalog/runtime behavior:
+  - `provider-catalog.ts`
+  - `provider-discovery.ts`
+  - `runtime.ts`
+- Search and media:
+  - `web-search.ts`
+  - `image-generation-provider.ts`
+- Docs and metadata:
+  - `README.md`
+  - `openclaw.plugin.json`
+  - `docs/*.md`
+- Tests:
+  - `repair.test.ts`
+  - `index.test.ts`
+  - `runtime.test.ts`
+  - capability-specific test files next to the owning module

--- a/index.test.ts
+++ b/index.test.ts
@@ -234,7 +234,8 @@ describe("nanogpt plugin entry", () => {
       modelId: "mistralai/mistral-large-3-675b-instruct-2512",
       model: { id: "mistralai/mistral-large-3-675b-instruct-2512" },
     });
-    expect(mistralStreamFn).toBe(baseStreamFn);
+    expect(mistralStreamFn).toEqual(expect.any(Function));
+    expect(mistralStreamFn).not.toBe(baseStreamFn);
 
     const kimiStreamFn = provider.wrapStreamFn?.({
       streamFn: baseStreamFn,

--- a/index.ts
+++ b/index.ts
@@ -385,6 +385,11 @@ function normalizeNanoGptToolSchemas(
   return changed ? tools : null;
 }
 
+function shouldDebugNanoGptToolReliability(): boolean {
+  const raw = process.env.NANOGPT_DEBUG_TOOL_RELIABILITY?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
 export default definePluginEntry({
   id: NANOGPT_PROVIDER_ID,
   name: "NanoGPT Provider",
@@ -457,7 +462,9 @@ export default definePluginEntry({
           if (!shouldRepairNanoGptToolCallArguments(repairModelId)) {
             return ctx.streamFn;
           }
-          return wrapStreamWithToolCallRepair(ctx.streamFn, api.logger);
+          return wrapStreamWithToolCallRepair(ctx.streamFn, api.logger, {
+            debug: shouldDebugNanoGptToolReliability(),
+          });
         }
         return undefined;
       },

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./runtime.js";
 import {
   shouldRepairNanoGptToolCallArguments,
+  wrapStreamWithMalformedToolCallGuard,
   wrapStreamWithToolCallRepair,
 } from "./repair.js";
 import { createNanoGptWebSearchProvider } from "./web-search.js";
@@ -459,12 +460,17 @@ export default definePluginEntry({
         if (ctx.streamFn) {
           const repairModelId =
             typeof ctx.model?.id === "string" && ctx.model.id.trim() ? ctx.model.id : ctx.modelId;
-          if (!shouldRepairNanoGptToolCallArguments(repairModelId)) {
-            return ctx.streamFn;
-          }
-          return wrapStreamWithToolCallRepair(ctx.streamFn, api.logger, {
+          const reliabilityOptions = {
             debug: shouldDebugNanoGptToolReliability(),
-          });
+          };
+          if (!shouldRepairNanoGptToolCallArguments(repairModelId)) {
+            return wrapStreamWithMalformedToolCallGuard(
+              ctx.streamFn,
+              api.logger,
+              reliabilityOptions,
+            );
+          }
+          return wrapStreamWithToolCallRepair(ctx.streamFn, api.logger, reliabilityOptions);
         }
         return undefined;
       },

--- a/repair.test.ts
+++ b/repair.test.ts
@@ -5,6 +5,29 @@ import {
 } from "./repair.js";
 import type { AssistantMessageEvent } from "@mariozechner/pi-ai";
 
+const DEFAULT_USAGE = {
+  input: 0,
+  output: 0,
+  totalTokens: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function createAssistantMessage(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    role: "assistant",
+    content: [],
+    api: "openai-completions",
+    provider: "nanogpt",
+    model: "test-model",
+    usage: { ...DEFAULT_USAGE, cost: { ...DEFAULT_USAGE.cost } },
+    stopReason: "stop",
+    timestamp: Date.now(),
+    ...overrides,
+  } as any;
+}
+
 describe("shouldRepairNanoGptToolCallArguments", () => {
   it("only enables repair for Kimi-style NanoGPT model ids", () => {
     expect(shouldRepairNanoGptToolCallArguments("moonshotai/kimi-k2.5")).toBe(true);
@@ -252,5 +275,315 @@ describe("wrapStreamWithToolCallRepair", () => {
 
     const resultMessage = await boundResult();
     expect(resultMessage.content[0].arguments).toEqual({ location: "Berlin" });
+  });
+
+  it("salvages fenced structured tool payloads from assistant text", async () => {
+    const toolPayload = [
+      "Sure — retrying with a structured payload.",
+      "```json",
+      JSON.stringify({
+        tool_calls: [
+          {
+            name: "get_weather",
+            arguments: {
+              location: "Paris",
+            },
+          },
+        ],
+      }),
+      "```",
+    ].join("\n");
+
+    const mockEvents: AssistantMessageEvent[] = [
+      {
+        type: "start",
+        partial: createAssistantMessage(),
+      },
+      {
+        type: "text_start",
+        contentIndex: 0,
+        partial: createAssistantMessage({
+          content: [{ type: "text", text: "" }],
+        }),
+      },
+      {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: toolPayload,
+        partial: createAssistantMessage({
+          content: [{ type: "text", text: toolPayload }],
+        }),
+      },
+      {
+        type: "text_end",
+        contentIndex: 0,
+        content: toolPayload,
+        partial: createAssistantMessage({
+          content: [{ type: "text", text: toolPayload }],
+        }),
+      },
+      {
+        type: "done",
+        reason: "stop",
+        message: createAssistantMessage({
+          content: [{ type: "text", text: toolPayload }],
+        }),
+      },
+    ];
+
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      for (const event of mockEvents) {
+        yield event;
+      }
+    })());
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const resultStream = await wrapped(
+      { id: "moonshotai/kimi-k2.5", api: "openai-completions" } as any,
+      {
+        messages: [],
+        tools: [
+          {
+            name: "get_weather",
+            description: "Weather lookup",
+            parameters: { type: "object" },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    const receivedEvents: AssistantMessageEvent[] = [];
+    for await (const event of resultStream) {
+      receivedEvents.push(event);
+    }
+
+    const toolEndEvent = receivedEvents.find((event) => event.type === "toolcall_end") as any;
+    expect(toolEndEvent.toolCall.name).toBe("get_weather");
+    expect(toolEndEvent.toolCall.arguments).toEqual({ location: "Paris" });
+
+    const doneEvent = receivedEvents.find((event) => event.type === "done") as any;
+    expect(doneEvent.reason).toBe("toolUse");
+    expect(doneEvent.message.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_salvaged_1",
+        name: "get_weather",
+        arguments: { location: "Paris" },
+      },
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Salvaged structured tool payload"),
+    );
+  });
+
+  it("salvages flattened tool arguments from assistant text", async () => {
+    const toolPayload = JSON.stringify({
+      tool_calls: [
+        {
+          name: "bash",
+          command: "mkdir -p src tests",
+          description: "Create folders",
+        },
+      ],
+    });
+
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      yield {
+        type: "done",
+        reason: "stop",
+        message: createAssistantMessage({
+          content: [{ type: "text", text: toolPayload }],
+        }),
+      } satisfies AssistantMessageEvent;
+    })());
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const resultStream = await wrapped(
+      { id: "moonshotai/kimi-k2.5", api: "openai-completions" } as any,
+      {
+        messages: [],
+        tools: [
+          {
+            name: "bash",
+            description: "Run a shell command",
+            parameters: { type: "object" },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    const doneMessage = await (resultStream as any).result();
+    expect(doneMessage.stopReason).toBe("toolUse");
+    expect(doneMessage.content[0]).toEqual({
+      type: "toolCall",
+      id: "call_salvaged_1",
+      name: "bash",
+      arguments: {
+        command: "mkdir -p src tests",
+        description: "Create folders",
+      },
+    });
+  });
+
+  it("retries one empty tool-enabled turn once and appends a retry prompt", async () => {
+    const emptyAttempt = (async function* () {
+      yield {
+        type: "start",
+        partial: createAssistantMessage(),
+      } satisfies AssistantMessageEvent;
+      yield {
+        type: "done",
+        reason: "stop",
+        message: createAssistantMessage(),
+      } satisfies AssistantMessageEvent;
+    })();
+
+    const successfulAttempt = (async function* () {
+      yield {
+        type: "start",
+        partial: createAssistantMessage(),
+      } satisfies AssistantMessageEvent;
+      yield {
+        type: "toolcall_start",
+        contentIndex: 0,
+        partial: createAssistantMessage({
+          content: [{ type: "toolCall", id: "call_retry", name: "get_weather", arguments: {} }],
+        }),
+      } satisfies AssistantMessageEvent;
+      yield {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '{"location":"Berlin"}',
+        partial: createAssistantMessage({
+          content: [
+            {
+              type: "toolCall",
+              id: "call_retry",
+              name: "get_weather",
+              arguments: { location: "Berlin" },
+            },
+          ],
+        }),
+      } satisfies AssistantMessageEvent;
+      yield {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: {
+          type: "toolCall",
+          id: "call_retry",
+          name: "get_weather",
+          arguments: { location: "Berlin" },
+        },
+        partial: createAssistantMessage({
+          content: [
+            {
+              type: "toolCall",
+              id: "call_retry",
+              name: "get_weather",
+              arguments: { location: "Berlin" },
+            },
+          ],
+        }),
+      } satisfies AssistantMessageEvent;
+      yield {
+        type: "done",
+        reason: "toolUse",
+        message: createAssistantMessage({
+          content: [
+            {
+              type: "toolCall",
+              id: "call_retry",
+              name: "get_weather",
+              arguments: { location: "Berlin" },
+            },
+          ],
+          stopReason: "toolUse",
+        }),
+      } satisfies AssistantMessageEvent;
+    })();
+
+    const mockStreamFn = vi
+      .fn()
+      .mockResolvedValueOnce(emptyAttempt)
+      .mockResolvedValueOnce(successfulAttempt);
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const resultStream = await wrapped(
+      { id: "moonshotai/kimi-k2.5", api: "openai-completions" } as any,
+      {
+        systemPrompt: "Use tools when needed.",
+        messages: [],
+        tools: [
+          {
+            name: "get_weather",
+            description: "Weather lookup",
+            parameters: { type: "object" },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    expect(mockStreamFn).toHaveBeenCalledTimes(2);
+    expect(mockStreamFn.mock.calls[1]?.[1]?.systemPrompt).toContain(
+      "previous response was invalid because it produced no visible content or tool call",
+    );
+
+    const doneMessage = await (resultStream as any).result();
+    expect(doneMessage.stopReason).toBe("toolUse");
+    expect(doneMessage.content[0].arguments).toEqual({ location: "Berlin" });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Retrying empty tool-enabled turn"),
+    );
+  });
+
+  it("emits structured debug artifacts when debug mode is enabled", async () => {
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      yield {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '{"location":"Mad',
+        partial: createAssistantMessage({
+          content: [{ type: "toolCall", id: "call_debug", name: "get_weather", arguments: {} }],
+        }),
+      } satisfies AssistantMessageEvent;
+      yield {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: {
+          type: "toolCall",
+          id: "call_debug",
+          name: "get_weather",
+          arguments: {},
+        },
+        partial: createAssistantMessage({
+          content: [{ type: "toolCall", id: "call_debug", name: "get_weather", arguments: {} }],
+        }),
+      } satisfies AssistantMessageEvent;
+    })());
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger, { debug: true });
+    const resultStream = await wrapped(
+      { id: "moonshotai/kimi-k2.5", api: "openai-completions" } as any,
+      { messages: [], tools: [] } as any,
+      {} as any,
+    );
+
+    for await (const _event of resultStream) {
+      // Exhaust stream
+    }
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"repair_success"'),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('"repairStage":"toolcall_end"'),
+    );
   });
 });

--- a/repair.test.ts
+++ b/repair.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   shouldRepairNanoGptToolCallArguments,
+  wrapStreamWithMalformedToolCallGuard,
   wrapStreamWithToolCallRepair,
 } from "./repair.js";
 import type { AssistantMessageEvent } from "@mariozechner/pi-ai";
@@ -584,6 +585,72 @@ describe("wrapStreamWithToolCallRepair", () => {
     );
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringContaining('"repairStage":"toolcall_end"'),
+    );
+  });
+});
+
+describe("wrapStreamWithMalformedToolCallGuard", () => {
+  it("logs malformed tool-call arguments for non-Kimi models without mutating them", async () => {
+    const mockEvents: AssistantMessageEvent[] = [
+      {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '{"location":"Mad',
+        partial: createAssistantMessage({
+          content: [{ type: "toolCall", id: "call_guard", name: "get_weather", arguments: {} }],
+        }),
+      },
+      {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall: {
+          type: "toolCall",
+          id: "call_guard",
+          name: "get_weather",
+          arguments: {},
+        },
+        partial: createAssistantMessage({
+          content: [{ type: "toolCall", id: "call_guard", name: "get_weather", arguments: {} }],
+        }),
+      },
+      {
+        type: "done",
+        reason: "toolUse",
+        message: createAssistantMessage({
+          content: [{ type: "toolCall", id: "call_guard", name: "get_weather", arguments: {} }],
+          stopReason: "toolUse",
+        }),
+      },
+    ];
+
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      for (const event of mockEvents) {
+        yield event;
+      }
+    })());
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithMalformedToolCallGuard(mockStreamFn as any, logger, {
+      debug: true,
+    });
+    const resultStream = await wrapped(
+      { id: "mistralai/mistral-large-3-675b-instruct-2512", api: "openai-completions" } as any,
+      { messages: [], tools: [] } as any,
+      {} as any,
+    );
+
+    const receivedEvents: AssistantMessageEvent[] = [];
+    for await (const event of resultStream) {
+      receivedEvents.push(event);
+    }
+
+    const toolEndEvent = receivedEvents.find((event) => event.type === "toolcall_end") as any;
+    expect(toolEndEvent.toolCall.arguments).toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Observed malformed tool call arguments from model mistralai/mistral-large-3-675b-instruct-2512"),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"malformed_tool_call_observed"'),
     );
   });
 });

--- a/repair.ts
+++ b/repair.ts
@@ -2,6 +2,7 @@ import { jsonrepair } from "jsonrepair";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
+  Tool,
 } from "@mariozechner/pi-ai";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 
@@ -10,9 +11,67 @@ export type RepairLogger = {
   info: (message: string) => void;
 };
 
+export type ToolCallRepairOptions = {
+  debug?: boolean;
+  retryInvalidEmptyTurns?: boolean;
+};
+
+type RepairRuntimeMeta = {
+  modelId: string;
+  requestApi?: string;
+  attempt: number;
+  debug: boolean;
+};
+
+type RepairAttempt = {
+  events: AssistantMessageEvent[];
+  finalMessage: AssistantMessage;
+  toolEnabled: boolean;
+  sawToolCall: boolean;
+  sawVisibleText: boolean;
+};
+
+const EMPTY_USAGE: AssistantMessage["usage"] = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+};
+
+const INVALID_EMPTY_TOOL_TURN_RETRY_PROMPT =
+  "NanoGPT retry note: the previous response was invalid because it produced no visible content or tool call for a tool-enabled turn. Reply again with either concise visible text or a valid tool call. If you use a tool, emit the tool call directly with valid JSON arguments and no markdown fences.";
+
+const TOOL_CALL_CONTAINER_KEYS = ["tool_calls", "toolCalls", "tools", "calls", "actions"] as const;
+const TOOL_ARGUMENT_KEYS = ["arguments", "args", "parameters", "input"] as const;
+const TOOL_CALL_RESERVED_KEYS = new Set<string>([
+  "id",
+  "type",
+  "name",
+  "tool",
+  "toolName",
+  "function",
+  "message",
+  "text",
+  "mode",
+  ...TOOL_ARGUMENT_KEYS,
+  ...TOOL_CALL_CONTAINER_KEYS,
+]);
+
 function normalizeNanoGptRepairModelId(modelId: string): string {
   const normalized = modelId.trim().toLowerCase();
   return normalized.startsWith("nanogpt/") ? normalized.slice("nanogpt/".length) : normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function shouldRepairNanoGptToolCallArguments(modelId?: string): boolean {
@@ -23,6 +82,508 @@ export function shouldRepairNanoGptToolCallArguments(modelId?: string): boolean 
   return normalized.startsWith("moonshotai/kimi");
 }
 
+function normalizeAssistantMessage(
+  message: Partial<AssistantMessage> | undefined,
+  meta: Pick<RepairRuntimeMeta, "modelId" | "requestApi">,
+): AssistantMessage {
+  const candidate = isRecord(message) ? (message as Partial<AssistantMessage>) : undefined;
+  return {
+    role: "assistant",
+    content: Array.isArray(candidate?.content) ? [...candidate.content] : [],
+    api: typeof candidate?.api === "string" ? candidate.api : meta.requestApi ?? "openai-completions",
+    provider: typeof candidate?.provider === "string" ? candidate.provider : "nanogpt",
+    model: typeof candidate?.model === "string" ? candidate.model : meta.modelId,
+    ...(typeof candidate?.responseId === "string" ? { responseId: candidate.responseId } : {}),
+    usage: isRecord(candidate?.usage)
+      ? (candidate.usage as AssistantMessage["usage"])
+      : {
+          ...EMPTY_USAGE,
+          cost: { ...EMPTY_USAGE.cost },
+        },
+    stopReason: candidate?.stopReason ?? "stop",
+    ...(typeof candidate?.errorMessage === "string" ? { errorMessage: candidate.errorMessage } : {}),
+    timestamp: typeof candidate?.timestamp === "number" ? candidate.timestamp : Date.now(),
+  };
+}
+
+function hasVisibleText(message: AssistantMessage): boolean {
+  return message.content.some(
+    (block) => block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0,
+  );
+}
+
+function countToolCalls(message: AssistantMessage): number {
+  return message.content.filter((block) => block.type === "toolCall").length;
+}
+
+function hasToolEnabledContext(context: Parameters<StreamFn>[1]): boolean {
+  return Array.isArray(context?.tools) && context.tools.length > 0;
+}
+
+function canonicalizeToolName(name: string): string {
+  return name.trim().toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function resolveKnownToolName(name: string, tools: readonly Tool[]): string {
+  const normalized = canonicalizeToolName(name);
+  const match = tools.find((tool) => canonicalizeToolName(tool.name) === normalized);
+  return match?.name ?? name.trim();
+}
+
+function logReliabilityArtifact(
+  logger: RepairLogger,
+  meta: RepairRuntimeMeta,
+  artifact: Record<string, unknown>,
+): void {
+  if (!meta.debug) {
+    return;
+  }
+
+  logger.info(
+    `[nanogpt][tool-reliability] ${JSON.stringify({
+      modelId: meta.modelId,
+      requestApi: meta.requestApi ?? "unknown",
+      attempt: meta.attempt,
+      ...artifact,
+    })}`,
+  );
+}
+
+function buildRetryContext(context: Parameters<StreamFn>[1]): Parameters<StreamFn>[1] {
+  return {
+    ...context,
+    systemPrompt: context.systemPrompt?.trim()
+      ? `${context.systemPrompt}\n\n${INVALID_EMPTY_TOOL_TURN_RETRY_PROMPT}`
+      : INVALID_EMPTY_TOOL_TURN_RETRY_PROMPT,
+  };
+}
+
+function parseJsonCandidate(candidate: string): unknown {
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    return JSON.parse(jsonrepair(candidate));
+  }
+}
+
+function extractBalancedJsonCandidate(text: string, opener: "{" | "[", closer: "}" | "]") {
+  let startIndex = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) {
+      continue;
+    }
+    if (char === opener) {
+      if (startIndex === -1) {
+        startIndex = index;
+      }
+      depth += 1;
+      continue;
+    }
+    if (char === closer && startIndex !== -1) {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function extractToolPayloadCandidates(text: string): string[] {
+  const candidates = new Set<string>();
+  const trimmed = text.trim();
+  if (trimmed) {
+    candidates.add(trimmed);
+  }
+
+  const fencedBlockPattern = /```(?:json)?\s*([\s\S]*?)```/gi;
+  for (const match of trimmed.matchAll(fencedBlockPattern)) {
+    const candidate = match[1]?.trim();
+    if (candidate) {
+      candidates.add(candidate);
+    }
+  }
+
+  const objectCandidate = extractBalancedJsonCandidate(trimmed, "{", "}");
+  if (objectCandidate) {
+    candidates.add(objectCandidate.trim());
+  }
+
+  const arrayCandidate = extractBalancedJsonCandidate(trimmed, "[", "]");
+  if (arrayCandidate) {
+    candidates.add(arrayCandidate.trim());
+  }
+
+  return [...candidates];
+}
+
+function firstDefinedProperty(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): unknown {
+  for (const key of keys) {
+    if (key in record && record[key] !== undefined) {
+      return record[key];
+    }
+  }
+  return undefined;
+}
+
+function firstStringProperty(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  const value = firstDefinedProperty(record, keys);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeToolArguments(raw: unknown): Record<string, unknown> | null {
+  if (isRecord(raw)) {
+    return { ...raw };
+  }
+  if (typeof raw !== "string" || !raw.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = parseJsonCandidate(raw.trim());
+    if (isRecord(parsed)) {
+      return { ...parsed };
+    }
+    if (Array.isArray(parsed)) {
+      return { value: parsed };
+    }
+    return { value: parsed };
+  } catch {
+    return null;
+  }
+}
+
+function buildFlattenedToolArguments(
+  record: Record<string, unknown>,
+  nestedFunction?: Record<string, unknown>,
+): Record<string, unknown> {
+  const flattened: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (!TOOL_CALL_RESERVED_KEYS.has(key)) {
+      flattened[key] = value;
+    }
+  }
+
+  if (Object.keys(flattened).length > 0) {
+    return flattened;
+  }
+
+  if (nestedFunction) {
+    for (const [key, value] of Object.entries(nestedFunction)) {
+      if (!TOOL_CALL_RESERVED_KEYS.has(key)) {
+        flattened[key] = value;
+      }
+    }
+  }
+
+  return flattened;
+}
+
+function normalizeSalvagedToolCall(
+  value: unknown,
+  tools: readonly Tool[],
+  index: number,
+): Extract<AssistantMessage["content"][number], { type: "toolCall" }> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const nestedFunction = isRecord(value.function) ? value.function : undefined;
+  const rawName =
+    firstStringProperty(value, ["name", "toolName"]) ??
+    (typeof value.tool === "string" && value.tool.trim() ? value.tool.trim() : undefined) ??
+    (nestedFunction ? firstStringProperty(nestedFunction, ["name"]) : undefined);
+  if (!rawName) {
+    return null;
+  }
+
+  const normalizedName = resolveKnownToolName(rawName, tools);
+  const rawArguments =
+    firstDefinedProperty(value, TOOL_ARGUMENT_KEYS) ??
+    (nestedFunction ? firstDefinedProperty(nestedFunction, TOOL_ARGUMENT_KEYS) : undefined);
+  const normalizedArguments =
+    normalizeToolArguments(rawArguments) ?? buildFlattenedToolArguments(value, nestedFunction);
+
+  return {
+    type: "toolCall",
+    id: typeof value.id === "string" && value.id.trim() ? value.id : `call_salvaged_${index + 1}`,
+    name: normalizedName,
+    arguments: normalizedArguments,
+  };
+}
+
+function normalizeStructuredToolTurn(
+  value: unknown,
+  tools: readonly Tool[],
+): {
+  messageText?: string;
+  toolCalls: Array<Extract<AssistantMessage["content"][number], { type: "toolCall" }>>;
+} | null {
+  if (Array.isArray(value)) {
+    const toolCalls = value
+      .map((entry, index) => normalizeSalvagedToolCall(entry, tools, index))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    return toolCalls.length > 0 ? { toolCalls } : null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const messageText =
+    (typeof value.message === "string" && value.message.trim() ? value.message.trim() : undefined) ??
+    (typeof value.text === "string" && value.text.trim() ? value.text.trim() : undefined);
+  const rawCalls = firstDefinedProperty(value, TOOL_CALL_CONTAINER_KEYS);
+  if (rawCalls !== undefined) {
+    const callEntries = Array.isArray(rawCalls) ? rawCalls : [rawCalls];
+    const toolCalls = callEntries
+      .map((entry, index) => normalizeSalvagedToolCall(entry, tools, index))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    return toolCalls.length > 0 ? { messageText, toolCalls } : null;
+  }
+
+  const toolCall = normalizeSalvagedToolCall(value, tools, 0);
+  return toolCall ? { messageText, toolCalls: [toolCall] } : null;
+}
+
+function buildSyntheticToolEvents(message: AssistantMessage): AssistantMessageEvent[] {
+  const partial = normalizeAssistantMessage(
+    {
+      ...message,
+      content: [],
+      stopReason: "toolUse",
+      errorMessage: undefined,
+    },
+    { modelId: message.model, requestApi: message.api },
+  );
+  const events: AssistantMessageEvent[] = [{ type: "start", partial }];
+
+  for (const [contentIndex, block] of message.content.entries()) {
+    if (block.type === "text") {
+      const partialTextBlock: Extract<AssistantMessage["content"][number], { type: "text" }> = {
+        type: "text",
+        text: "",
+      };
+      partial.content.push(partialTextBlock);
+      events.push({ type: "text_start", contentIndex, partial });
+      if (block.text) {
+        partialTextBlock.text = block.text;
+        events.push({ type: "text_delta", contentIndex, delta: block.text, partial });
+      }
+      events.push({ type: "text_end", contentIndex, content: block.text, partial });
+      continue;
+    }
+
+    if (block.type === "toolCall") {
+      const partialToolCall: Extract<AssistantMessage["content"][number], { type: "toolCall" }> = {
+        type: "toolCall",
+        id: block.id,
+        name: block.name,
+        arguments: {},
+      };
+      partial.content.push(partialToolCall);
+      events.push({ type: "toolcall_start", contentIndex, partial });
+      const delta = JSON.stringify(block.arguments);
+      partialToolCall.arguments = block.arguments;
+      if (delta) {
+        events.push({ type: "toolcall_delta", contentIndex, delta, partial });
+      }
+      events.push({ type: "toolcall_end", contentIndex, toolCall: block, partial });
+    }
+  }
+
+  events.push({ type: "done", reason: "toolUse", message });
+  return events;
+}
+
+function salvageStructuredToolTurn(
+  message: AssistantMessage,
+  tools: readonly Tool[],
+  meta: RepairRuntimeMeta,
+  logger: RepairLogger,
+): { events: AssistantMessageEvent[]; finalMessage: AssistantMessage } | null {
+  const textPayload = message.content
+    .filter((block): block is Extract<AssistantMessage["content"][number], { type: "text" }> => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+  if (!textPayload) {
+    return null;
+  }
+
+  for (const candidate of extractToolPayloadCandidates(textPayload)) {
+    try {
+      const normalized = normalizeStructuredToolTurn(parseJsonCandidate(candidate), tools);
+      if (!normalized || normalized.toolCalls.length === 0) {
+        continue;
+      }
+
+      const salvagedMessage = normalizeAssistantMessage(message, meta);
+      salvagedMessage.content = [
+        ...(normalized.messageText ? [{ type: "text", text: normalized.messageText } as const] : []),
+        ...normalized.toolCalls,
+      ];
+      salvagedMessage.stopReason = "toolUse";
+      delete salvagedMessage.errorMessage;
+
+      logger.warn(
+        `[nanogpt] Salvaged structured tool payload from assistant text for model ${meta.modelId}`,
+      );
+      logReliabilityArtifact(logger, meta, {
+        event: "salvage_success",
+        toolCallCount: normalized.toolCalls.length,
+        payloadLength: textPayload.length,
+      });
+
+      return {
+        events: buildSyntheticToolEvents(salvagedMessage),
+        finalMessage: salvagedMessage,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function createReplayStream(events: AssistantMessageEvent[], finalMessage: AssistantMessage) {
+  return {
+    async result() {
+      return finalMessage;
+    },
+    [Symbol.asyncIterator]() {
+      let index = 0;
+      return {
+        async next() {
+          if (index >= events.length) {
+            return { done: true as const, value: undefined };
+          }
+          const value = events[index];
+          index += 1;
+          return { done: false as const, value };
+        },
+        async return(value?: unknown) {
+          return { done: true as const, value };
+        },
+        async throw(error?: unknown) {
+          return Promise.reject(error);
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    },
+  };
+}
+
+async function collectRepairAttempt(params: {
+  streamFn: StreamFn;
+  args: Parameters<StreamFn>;
+  logger: RepairLogger;
+  meta: RepairRuntimeMeta;
+}): Promise<RepairAttempt> {
+  const stream = await params.streamFn(...params.args);
+  const toolCallArgBuffers = new Map<number, string>();
+  const events: AssistantMessageEvent[] = [];
+  let lastAssistantMessage: AssistantMessage | undefined;
+  let sawToolCall = false;
+
+  for await (const event of stream) {
+    const repairedEvent = repairAssistantMessageEvent(
+      event,
+      toolCallArgBuffers,
+      params.meta,
+      params.logger,
+    );
+    if (
+      repairedEvent.type === "toolcall_start" ||
+      repairedEvent.type === "toolcall_delta" ||
+      repairedEvent.type === "toolcall_end"
+    ) {
+      sawToolCall = true;
+    }
+    if ("partial" in repairedEvent) {
+      lastAssistantMessage = repairedEvent.partial;
+    }
+    if (repairedEvent.type === "done") {
+      lastAssistantMessage = repairedEvent.message;
+    }
+    if (repairedEvent.type === "error") {
+      lastAssistantMessage = repairedEvent.error;
+    }
+    events.push(repairedEvent);
+  }
+
+  const terminalEvent = [...events].reverse().find(
+    (event): event is Extract<AssistantMessageEvent, { type: "done" | "error" }> =>
+      event.type === "done" || event.type === "error",
+  );
+  let finalMessage =
+    terminalEvent?.type === "done"
+      ? terminalEvent.message
+      : terminalEvent?.type === "error"
+        ? terminalEvent.error
+        : normalizeAssistantMessage(lastAssistantMessage, params.meta);
+  const toolEnabled = hasToolEnabledContext(params.args[1]);
+
+  if (toolEnabled && !sawToolCall && countToolCalls(finalMessage) === 0) {
+    const salvaged = salvageStructuredToolTurn(
+      finalMessage,
+      params.args[1].tools ?? [],
+      params.meta,
+      params.logger,
+    );
+    if (salvaged) {
+      finalMessage = salvaged.finalMessage;
+      return {
+        events: salvaged.events,
+        finalMessage,
+        toolEnabled,
+        sawToolCall: true,
+        sawVisibleText: hasVisibleText(finalMessage),
+      };
+    }
+  }
+
+  const finalToolCallCount = countToolCalls(finalMessage);
+  if (finalToolCallCount > 0) {
+    sawToolCall = true;
+  }
+
+  return {
+    events,
+    finalMessage,
+    toolEnabled,
+    sawToolCall,
+    sawVisibleText: hasVisibleText(finalMessage),
+  };
+}
+
 /**
  * Wraps an OpenClaw model stream to automatically repair malformed JSON in tool call arguments.
  * This is particularly useful for "thinking" models or models that may truncate output.
@@ -30,68 +591,60 @@ export function shouldRepairNanoGptToolCallArguments(modelId?: string): boolean 
 export function wrapStreamWithToolCallRepair(
   streamFn: StreamFn,
   logger: RepairLogger,
+  options: ToolCallRepairOptions = {},
 ): StreamFn {
   return async (...args) => {
-    const stream = await streamFn(...args);
-    const modelId = args[0]?.id || "unknown";
-
-    return wrapToolCallRepairStream(stream, modelId, logger) as any;
-  };
-}
-
-function wrapToolCallRepairStream<TStream extends AsyncIterable<AssistantMessageEvent>>(
-  stream: TStream,
-  modelId: string,
-  logger: RepairLogger,
-): TStream {
-  const toolCallArgBuffers = new Map<number, string>();
-  const wrappedStream = stream as TStream & {
-    result?: () => Promise<AssistantMessage>;
-    [Symbol.asyncIterator]: () => AsyncIterator<AssistantMessageEvent>;
-  };
-
-  const originalAsyncIterator = wrappedStream[Symbol.asyncIterator].bind(wrappedStream);
-  wrappedStream[Symbol.asyncIterator] = function () {
-    const iterator = originalAsyncIterator();
-    return {
-      async next() {
-        const result = await iterator.next();
-        if (result.done) {
-          return result;
-        }
-
-        return {
-          done: false as const,
-          value: repairAssistantMessageEvent(result.value, toolCallArgBuffers, modelId, logger),
-        };
-      },
-      async return(value?: unknown) {
-        return iterator.return?.(value) ?? { done: true as const, value: undefined };
-      },
-      async throw(error?: unknown) {
-        return iterator.throw?.(error) ?? Promise.reject(error);
-      },
-      [Symbol.asyncIterator]() {
-        return this;
-      },
+    const baseMeta: RepairRuntimeMeta = {
+      modelId: args[0]?.id || "unknown",
+      requestApi: args[0]?.api,
+      attempt: 0,
+      debug: options.debug === true,
     };
+    const firstAttempt = await collectRepairAttempt({
+      streamFn,
+      args,
+      logger,
+      meta: baseMeta,
+    });
+
+    let selectedAttempt = firstAttempt;
+    if (
+      options.retryInvalidEmptyTurns !== false &&
+      firstAttempt.toolEnabled &&
+      !firstAttempt.sawToolCall &&
+      !firstAttempt.sawVisibleText
+    ) {
+      logger.warn(
+        `[nanogpt] Retrying empty tool-enabled turn from model ${baseMeta.modelId} after no visible content or tool call was produced`,
+      );
+      logReliabilityArtifact(logger, baseMeta, {
+        event: "retry_invalid_empty_turn",
+      });
+
+      selectedAttempt = await collectRepairAttempt({
+        streamFn,
+        args: [args[0], buildRetryContext(args[1]), args[2]],
+        logger,
+        meta: {
+          ...baseMeta,
+          attempt: 1,
+        },
+      });
+      logReliabilityArtifact(logger, { ...baseMeta, attempt: 1 }, {
+        event: "retry_result",
+        recoveredToolCalls: countToolCalls(selectedAttempt.finalMessage),
+        sawVisibleText: selectedAttempt.sawVisibleText,
+      });
+    }
+
+    return createReplayStream(selectedAttempt.events, selectedAttempt.finalMessage) as any;
   };
-
-  if (typeof wrappedStream.result === "function") {
-    const originalResult = wrappedStream.result.bind(wrappedStream);
-    wrappedStream.result = async () => {
-      const message = await originalResult();
-      return repairAssistantMessage(message, toolCallArgBuffers, modelId, logger);
-    };
-  }
-
-  return wrappedStream;
 }
 
 function repairAssistantMessageEvent(
   event: AssistantMessageEvent,
   toolCallArgBuffers: Map<number, string>,
-  modelId: string,
+  meta: RepairRuntimeMeta,
   logger: RepairLogger,
 ): AssistantMessageEvent {
   if (event.type === "toolcall_delta") {
@@ -102,20 +655,20 @@ function repairAssistantMessageEvent(
 
   if (event.type === "toolcall_end") {
     const rawArgs = toolCallArgBuffers.get(event.contentIndex);
-    return rawArgs !== undefined ? repairToolCallEndEvent(event, rawArgs, modelId, logger) : event;
+    return rawArgs !== undefined ? repairToolCallEndEvent(event, rawArgs, meta, logger) : event;
   }
 
   if (event.type === "done") {
     return {
       ...event,
-      message: repairAssistantMessage(event.message, toolCallArgBuffers, modelId, logger),
+      message: repairAssistantMessage(event.message, toolCallArgBuffers, meta, logger),
     };
   }
 
   if (event.type === "error") {
     return {
       ...event,
-      error: repairAssistantMessage(event.error, toolCallArgBuffers, modelId, logger),
+      error: repairAssistantMessage(event.error, toolCallArgBuffers, meta, logger),
     };
   }
 
@@ -125,7 +678,7 @@ function repairAssistantMessageEvent(
 function repairToolCallEndEvent(
   event: Extract<AssistantMessageEvent, { type: "toolcall_end" }>,
   rawArgs: string,
-  modelId: string,
+  meta: RepairRuntimeMeta,
   logger: RepairLogger,
 ): AssistantMessageEvent {
   try {
@@ -138,8 +691,14 @@ function repairToolCallEndEvent(
       const parsed = JSON.parse(repairedJson);
 
       logger.warn(
-        `[nanogpt] Repaired malformed tool call arguments from model ${modelId} for tool "${event.toolCall.name}"`,
+        `[nanogpt] Repaired malformed tool call arguments from model ${meta.modelId} for tool "${event.toolCall.name}"`,
       );
+      logReliabilityArtifact(logger, meta, {
+        event: "repair_success",
+        repairStage: "toolcall_end",
+        toolName: event.toolCall.name,
+        rawArgumentLength: rawArgs.length,
+      });
 
       return {
         ...event,
@@ -147,9 +706,15 @@ function repairToolCallEndEvent(
           ...event.toolCall,
           arguments: parsed,
         },
-        partial: repairAssistantMessage(event.partial, new Map([[event.contentIndex, rawArgs]]), modelId, logger, true),
+        partial: repairAssistantMessage(event.partial, new Map([[event.contentIndex, rawArgs]]), meta, logger, true),
       };
-    } catch (e) {
+    } catch {
+      logReliabilityArtifact(logger, meta, {
+        event: "repair_failed",
+        repairStage: "toolcall_end",
+        toolName: event.toolCall.name,
+        rawArgumentLength: rawArgs.length,
+      });
       // If even jsonrepair fails, we just pass through and let the core handle the error
       return event;
     }
@@ -159,7 +724,7 @@ function repairToolCallEndEvent(
 function repairAssistantMessage(
   message: AssistantMessage,
   buffers: Map<number, string>,
-  modelId: string,
+  meta: RepairRuntimeMeta,
   logger: RepairLogger,
   silent = false,
 ): AssistantMessage {
@@ -180,12 +745,26 @@ function repairAssistantMessage(
           const parsed = JSON.parse(repairedJson);
           if (!silent) {
             logger.warn(
-              `[nanogpt] Repaired malformed tool call arguments in final message from model ${modelId} for tool "${block.name}"`,
+              `[nanogpt] Repaired malformed tool call arguments in final message from model ${meta.modelId} for tool "${block.name}"`,
             );
+            logReliabilityArtifact(logger, meta, {
+              event: "repair_success",
+              repairStage: "final_message",
+              toolName: block.name,
+              rawArgumentLength: rawArgs.length,
+            });
           }
           changed = true;
           return { ...block, arguments: parsed };
         } catch {
+          if (!silent) {
+            logReliabilityArtifact(logger, meta, {
+              event: "repair_failed",
+              repairStage: "final_message",
+              toolName: block.name,
+              rawArgumentLength: rawArgs.length,
+            });
+          }
           return block;
         }
       }

--- a/repair.ts
+++ b/repair.ts
@@ -149,6 +149,39 @@ function logReliabilityArtifact(
   );
 }
 
+function isMalformedToolCallJson(rawArgs: string): boolean {
+  try {
+    JSON.parse(rawArgs);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function logObservedMalformedToolCall(params: {
+  contentIndex: number;
+  toolName: string;
+  rawArgs: string;
+  logger: RepairLogger;
+  meta: RepairRuntimeMeta;
+  loggedContentIndexes: Set<number>;
+}): void {
+  if (params.loggedContentIndexes.has(params.contentIndex)) {
+    return;
+  }
+
+  params.loggedContentIndexes.add(params.contentIndex);
+  params.logger.warn(
+    `[nanogpt] Observed malformed tool call arguments from model ${params.meta.modelId} (api=${params.meta.requestApi ?? "unknown"}) for tool "${params.toolName}". Automatic repair is not enabled for this model family; investigate whether this model should get targeted reliability handling.`,
+  );
+  logReliabilityArtifact(params.logger, params.meta, {
+    event: "malformed_tool_call_observed",
+    toolName: params.toolName,
+    rawArgumentLength: params.rawArgs.length,
+    repairEnabled: false,
+  });
+}
+
 function buildRetryContext(context: Parameters<StreamFn>[1]): Parameters<StreamFn>[1] {
   return {
     ...context,
@@ -638,6 +671,102 @@ export function wrapStreamWithToolCallRepair(
     }
 
     return createReplayStream(selectedAttempt.events, selectedAttempt.finalMessage) as any;
+  };
+}
+
+export function wrapStreamWithMalformedToolCallGuard(
+  streamFn: StreamFn,
+  logger: RepairLogger,
+  options: ToolCallRepairOptions = {},
+): StreamFn {
+  return async (...args) => {
+    const stream = await streamFn(...args);
+    const meta: RepairRuntimeMeta = {
+      modelId: args[0]?.id || "unknown",
+      requestApi: args[0]?.api,
+      attempt: 0,
+      debug: options.debug === true,
+    };
+    const toolCallArgBuffers = new Map<number, string>();
+    const loggedContentIndexes = new Set<number>();
+    const wrappedStream = stream as typeof stream & {
+      result?: () => Promise<AssistantMessage>;
+      [Symbol.asyncIterator]: () => AsyncIterator<AssistantMessageEvent>;
+    };
+
+    const originalAsyncIterator = wrappedStream[Symbol.asyncIterator].bind(wrappedStream);
+    wrappedStream[Symbol.asyncIterator] = function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (result.done) {
+            return result;
+          }
+
+          const event = result.value;
+          if (event.type === "toolcall_delta") {
+            const current = toolCallArgBuffers.get(event.contentIndex) || "";
+            toolCallArgBuffers.set(event.contentIndex, current + event.delta);
+          }
+
+          if (event.type === "toolcall_end") {
+            const rawArgs = toolCallArgBuffers.get(event.contentIndex);
+            if (typeof rawArgs === "string" && isMalformedToolCallJson(rawArgs)) {
+              logObservedMalformedToolCall({
+                contentIndex: event.contentIndex,
+                toolName: event.toolCall.name,
+                rawArgs,
+                logger,
+                meta,
+                loggedContentIndexes,
+              });
+            }
+          }
+
+          return {
+            done: false as const,
+            value: event,
+          };
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? Promise.reject(error);
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+
+    if (typeof wrappedStream.result === "function") {
+      const originalResult = wrappedStream.result.bind(wrappedStream);
+      wrappedStream.result = async () => {
+        const message = await originalResult();
+        message.content.forEach((block, index) => {
+          if (block.type !== "toolCall") {
+            return;
+          }
+
+          const rawArgs = toolCallArgBuffers.get(index);
+          if (typeof rawArgs === "string" && isMalformedToolCallJson(rawArgs)) {
+            logObservedMalformedToolCall({
+              contentIndex: index,
+              toolName: block.name,
+              rawArgs,
+              logger,
+              meta,
+              loggedContentIndexes,
+            });
+          }
+        });
+        return message;
+      };
+    }
+
+    return wrappedStream as any;
   };
 }
 


### PR DESCRIPTION
Introduce a TODO.md for follow-up tasks and improve documentation alignment. Implement structured logging for tool-call reliability, including a debug mode for detailed diagnostics. Enhance repair mechanisms with one-shot retries and better handling of malformed tool calls. Update README.md to reflect these changes and clarify the tool support for `moonshotai/kimi*` models.