### PR TITLE
Support provider-prefixed model overrides in image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,13 @@ The plugin registers a NanoGPT image generation provider backed by:
 
 The default image model is `hidream`.
 
+When NanoGPT is the only configured image provider and `NANOGPT_API_KEY` is
+available, current OpenClaw builds can infer `nanogpt/hidream` automatically.
+You can still switch models per call with provider/model refs such as
+`nanogpt/chroma` or `nanogpt/qwen-image`; explicit
+`agents.defaults.imageGenerationModel.primary` is only needed if you want a
+different default pinned in config.
+
 ### Current image capabilities
 
 - generation and edit flows are enabled

--- a/image-generation-provider.test.ts
+++ b/image-generation-provider.test.ts
@@ -190,6 +190,40 @@ describe("nanogpt image-generation provider", () => {
     expect(result.model).toBe("qwen-image-2512");
   });
 
+  it("accepts provider-prefixed model overrides like nanogpt/chroma", async () => {
+    mockNanoGptApiKey();
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              b64_json: Buffer.from("chroma-data").toString("base64"),
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const provider = buildNanoGptImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "nanogpt",
+      model: "nanogpt/chroma",
+      prompt: "debugging in neon rain",
+      cfg: {},
+    });
+
+    expect(JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body))).toMatchObject({
+      model: "chroma",
+      prompt: "debugging in neon rain",
+    });
+    expect(result.model).toBe("chroma");
+  });
+
   it("surfaces curated model guidance when NanoGPT rejects an image model id", async () => {
     mockNanoGptApiKey();
     vi.stubGlobal(

--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -1,3 +1,4 @@
+import { NANOGPT_PROVIDER_ID } from "./models.js";
 import { sanitizeApiKey } from "./runtime.js";
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -54,8 +55,10 @@ function toDataUrl(buffer: Uint8Array, mimeType: string): string {
 }
 
 function normalizeImageModelName(model: string): string {
-  const normalizedKey = model.trim().toLowerCase().replace(/[_\s]+/g, " ");
-  return NANOGPT_IMAGE_MODEL_ALIASES.get(normalizedKey) ?? model.trim();
+  const trimmed = model.trim();
+  const withoutProviderPrefix = trimmed.replace(new RegExp(`^${NANOGPT_PROVIDER_ID}/`, "i"), "");
+  const normalizedKey = withoutProviderPrefix.toLowerCase().replace(/[_\s]+/g, " ");
+  return NANOGPT_IMAGE_MODEL_ALIASES.get(normalizedKey) ?? withoutProviderPrefix;
 }
 
 function buildUnsupportedModelGuidance(model: string): string {
@@ -68,7 +71,7 @@ function buildUnsupportedModelGuidance(model: string): string {
 
 export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
   return {
-    id: "nanogpt",
+    id: NANOGPT_PROVIDER_ID,
     label: "NanoGPT",
     defaultModel: NANOGPT_DEFAULT_IMAGE_MODEL,
     models: [...NANOGPT_IMAGE_MODELS],
@@ -93,7 +96,7 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
     },
     async generateImage(req) {
       const auth = await resolveApiKeyForProvider({
-        provider: "nanogpt",
+        provider: NANOGPT_PROVIDER_ID,
         cfg: req.cfg,
         agentDir: req.agentDir,
         store: req.authStore,


### PR DESCRIPTION
Enable the use of provider-prefixed model names for image generation, allowing for more flexible model selection. This includes automatic inference of the model when using the NanoGPT provider and updates to the image generation provider's implementation.