### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to external API calls to prevent resource exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The web search provider (`normalizeNanoGptWebSearchResult` in `web-search.ts`) was normalizing and returning URLs without verifying their protocol. This allowed `javascript:` or `data:` URLs to be passed downstream as valid results.
 **Learning:** Even when consuming data from a trusted third-party API (like NanoGPT web search), any URLs intended to be rendered or clicked must be explicitly sanitized to ensure they use safe protocols.
 **Prevention:** Use the `URL` constructor to parse incoming URLs and explicitly check that `parsedUrl.protocol` is either `http:` or `https:`. Return `null` for any URL that fails to parse or uses an unsafe scheme.
+## 2025-05-18 - Missing timeouts on external API calls
+**Vulnerability:** External fetch calls in `web-search.ts` and `image-generation-provider.ts` were missing timeout configurations, which could lead to resource exhaustion if the remote endpoints hang indefinitely.
+**Learning:** Relying on default `fetch` behavior for external APIs leaves the application susceptible to denial-of-service (DoS) conditions through connection hanging.
+**Prevention:** Always use `signal: AbortSignal.timeout(ms)` when making outbound network requests using `fetch` to ensure operations fail securely within an expected timeframe.

--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -136,6 +136,7 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
 
       const response = await fetch(`${NANOGPT_IMAGE_BASE_URL}/v1/images/generations`, {
         method: "POST",
+        signal: AbortSignal.timeout(60_000),
         headers: {
           Authorization: `Bearer ${sanitizeApiKey(auth.apiKey)}`,
           "Content-Type": "application/json",

--- a/web-search.ts
+++ b/web-search.ts
@@ -172,6 +172,7 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
 
         const response = await fetch(NANOGPT_WEB_SEARCH_URL, {
           method: "POST",
+          signal: AbortSignal.timeout(30_000),
           headers: {
             Authorization: `Bearer ${sanitizeApiKey(apiKey)}`,
             "Content-Type": "application/json",


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External `fetch` requests to NanoGPT's APIs (web search and image generation) lacked a timeout configuration. The default `fetch` in Node.js does not have a timeout, which can cause the application to hang indefinitely if the remote server is unresponsive.
🎯 **Impact:** Resource exhaustion and Denial of Service (DoS) due to hanging connections.
🔧 **Fix:** Added `signal: AbortSignal.timeout(30_000)` to the web search API call and `signal: AbortSignal.timeout(60_000)` to the image generation API call.
✅ **Verification:** Verified the fix by checking the changes in both modified files and running the test suite (`pnpm test`), which passed successfully.

---
*PR created automatically by Jules for task [18360165079748724038](https://jules.google.com/task/18360165079748724038) started by @deadronos*