### PR TITLE
Fix misleading NanoGPT catalog validation errors

### DIFF
--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildNanoGptProvider } from "./provider-catalog.js";
+import { NANOGPT_FALLBACK_MODELS } from "./models.js";
 import { resetNanoGptRuntimeState } from "./runtime.js";
 
 afterEach(() => {
@@ -371,33 +372,27 @@ describe("buildNanoGptProvider", () => {
     expect(provider.models[0]?.cost.cacheWrite).toBe(0);
   });
 
-  it("provides helpful error when responses API has no models but completions does", async () => {
+  it("keeps fallback discovery soft when responses catalog lookup fails", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    // First call (responses discovery): fail → returns fallback models
     fetchMock.mockResolvedValueOnce({
       ok: false,
       json: async () => ({}),
     });
 
-    // Second call (completions validation check): succeed → returns real models
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" }],
-      }),
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: {
+        routingMode: "paygo",
+        catalogSource: "canonical",
+        requestApi: "responses",
+      },
     });
 
-    await expect(
-      buildNanoGptProvider({
-        apiKey: "test-key",
-        pluginConfig: {
-          routingMode: "paygo",
-          catalogSource: "canonical",
-          requestApi: "responses",
-        },
-      }),
-    ).rejects.toThrow(/Responses API endpoint.*Chat Completions API/);
+    expect(provider.api).toBe("openai-responses");
+    expect(provider.baseUrl).toBe("https://nano-gpt.com/api/v1");
+    expect(provider.models.map((model) => model.id)).toEqual(NANOGPT_FALLBACK_MODELS.map((model) => model.id));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/provider-catalog.ts
+++ b/provider-catalog.ts
@@ -222,43 +222,6 @@ export function readNanoGptModelsJsonSnapshot(
   }
 }
 
-async function validateModelAvailabilityForApiChoice(params: {
-  apiKey: string;
-  config: NanoGptPluginConfig;
-  routingMode: string;
-  catalogSource: string;
-  discoveredModels: unknown[];
-}): Promise<string | null> {
-  // Only validate when responses is explicitly requested
-  if (params.config.requestApi !== "responses") {
-    return null;
-  }
-
-  // Only validate if discovery returned fallback models (indicating failure)
-  if (params.discoveredModels !== NANOGPT_FALLBACK_MODELS) {
-    return null;
-  }
-
-  // Try to discover models with completions API
-  const completionsModels = await discoverNanoGptModels({
-    apiKey: params.apiKey,
-    source: params.catalogSource as Exclude<import("./models.js").NanoGptCatalogSource, "auto">,
-    provider: params.config.provider,
-  });
-
-  // If completions has real models, let user know responses doesn't have them
-  if (completionsModels !== NANOGPT_FALLBACK_MODELS) {
-    return (
-      "NanoGPT models not available via Responses API endpoint. " +
-      "These models are available via the Chat Completions API instead. " +
-      "Either: (1) set requestApi to 'completions' or 'auto', " +
-      "or (2) check if different model IDs are supported by the Responses endpoint."
-    );
-  }
-
-  return null;
-}
-
 export async function buildNanoGptProvider(params: {
   apiKey: string;
   pluginConfig?: unknown;
@@ -277,20 +240,6 @@ export async function buildNanoGptProvider(params: {
     source: catalogSource,
     provider: config.provider,
   });
-
-  // Validate API choice: if responses was requested but models aren't found,
-  // check if they're available via completions and provide helpful error
-  const validationError = await validateModelAvailabilityForApiChoice({
-    apiKey: params.apiKey,
-    config,
-    routingMode,
-    catalogSource,
-    discoveredModels: models,
-  });
-
-  if (validationError) {
-    throw new Error(validationError);
-  }
 
   const resolvedHeaders = buildNanoGptRequestHeaders({
     apiKey: params.apiKey,


### PR DESCRIPTION
## Summary
- remove the catalog-build heuristic that retried the same discovery path and could misdiagnose a fallback as a Responses-vs-Completions mismatch
- keep `buildNanoGptProvider()` soft when NanoGPT model discovery falls back under `requestApi: "responses"`
- tighten the regression test to verify the fallback catalog is returned without a second validation fetch

## Why
The previous validation path did not actually prove an API transport mismatch. It retried discovery, and if that second call happened to succeed, the plugin threw a misleading error during provider discovery/onboarding instead of returning the normal fallback model set.

Closes #63.

## Validation
- `npx vitest run provider-catalog.test.ts`
- `npm test`
- `npm run typecheck`