### PR TITLE
Fix subscription billing errors with provider overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ The plugin config controls NanoGPT text-model discovery and transport behavior:
       nanogpt: {
         enabled: true,
         config: {
-          routingMode: "auto",
-          catalogSource: "auto",
-          requestApi: "responses",
+          routingMode: "paygo",
+          catalogSource: "canonical",
+          requestApi: "completions",
           provider: "openrouter"
         }
       }
@@ -172,7 +172,7 @@ For example:
 - `routingMode`: `auto`, `subscription`, `paygo`
 - `catalogSource`: `auto`, `canonical`, `subscription`, `paid`, `personalized`
 - `requestApi`: `auto`, `responses`, `completions`
-- `provider`: optional NanoGPT upstream provider id
+- `provider`: optional NanoGPT upstream provider id for paygo provider selection
 
 ### Behavior notes
 
@@ -202,9 +202,10 @@ For example:
 - The plugin does **not** currently alias `web_fetch` to `fetch_web_page` on
   `main`; that earlier experiment remains documented in repo history, but the
   alias is currently disabled in code.
-- `provider` adds NanoGPT's `X-Provider` override header for text requests.
-- if `provider` is set while the request would otherwise use subscription
-  routing, the plugin also sets `X-Billing-Mode: paygo`
+- `provider` adds NanoGPT's `X-Provider` override header only for paygo-routed
+  text requests.
+- subscription-routed text requests ignore `provider` so the plugin does not
+  push subscription calls onto a separate paygo billing path.
 - `requestApi: "responses"` on subscription routing uses NanoGPT's base API
   endpoint (`/api/v1`) rather than the subscription completions endpoint, so
   treat it as a separate compatibility/billing path from standard subscription
@@ -214,9 +215,10 @@ For example:
 
 By default, the plugin exposes pricing from NanoGPT's detailed model catalog.
 
-When `provider` is set, the plugin also tries to align exposed `models[].cost`
-with NanoGPT's provider-selection pricing endpoint so the model cost shown to
-OpenClaw better reflects the billed price for the selected upstream provider.
+When `provider` is set and text routing resolves to paygo, the plugin also
+tries to align exposed `models[].cost` with NanoGPT's provider-selection
+pricing endpoint so the model cost shown to OpenClaw better reflects the billed
+price for the selected upstream provider.
 
 If NanoGPT does not expose provider-selection pricing for a model, the plugin
 falls back to the default catalog pricing instead of failing model discovery.

--- a/openclaw-discovery.test.ts
+++ b/openclaw-discovery.test.ts
@@ -412,19 +412,13 @@ describe("NanoGPT OpenClaw discovery integration", () => {
       api: "openai-completions",
       apiKey: "NANOGPT_API_KEY",
       baseUrl: "https://nano-gpt.com/api/subscription/v1",
-      headers: {
-        "X-Billing-Mode": "paygo",
-        "X-Provider": "openrouter",
-      },
     });
+    expect(nanogptProvider?.headers).toBeUndefined();
     expect(serializedProvider).not.toContain("Authorization");
     expect(serializedProvider).not.toContain("Bearer NANOGPT_API_KEY");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       "https://nano-gpt.com/api/subscription/v1/models?detailed=true",
-    );
-    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
-      "https://nano-gpt.com/api/models/moonshotai%2Fkimi-k2.5%3Athinking/providers",
     );
   });
 });

--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -218,7 +218,7 @@ describe("buildNanoGptProvider", () => {
     expect(secondProvider.baseUrl).toBe("https://nano-gpt.com/api/subscription/v1");
   });
 
-  it("adds provider override headers and paygo billing override for subscription routing", async () => {
+  it("adds provider override headers for paygo routing", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -230,14 +230,13 @@ describe("buildNanoGptProvider", () => {
     const provider = await buildNanoGptProvider({
       apiKey: "test-key",
       pluginConfig: {
-        routingMode: "subscription",
-        catalogSource: "subscription",
+        routingMode: "paygo",
+        catalogSource: "canonical",
         provider: "openrouter",
       },
     });
 
     expect(provider.headers).toEqual({
-      "X-Billing-Mode": "paygo",
       "X-Provider": "openrouter",
     });
   });
@@ -254,16 +253,36 @@ describe("buildNanoGptProvider", () => {
     const provider = await buildNanoGptProvider({
       apiKey: "test-key",
       pluginConfig: {
-        routingMode: "subscription",
-        catalogSource: "subscription",
+        routingMode: "paygo",
+        catalogSource: "canonical",
         provider: "openrouter\r\nInjected: true",
       },
     });
 
     expect(provider.headers).toEqual({
-      "X-Billing-Mode": "paygo",
       "X-Provider": "openrouterInjected: true",
     });
+  });
+
+  it("ignores provider overrides on subscription routing to avoid paygo billing errors", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: [{ id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" }] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = await buildNanoGptProvider({
+      apiKey: "test-key",
+      pluginConfig: {
+        routingMode: "subscription",
+        catalogSource: "subscription",
+        provider: "openrouter",
+      },
+    });
+
+    expect(provider.baseUrl).toBe("https://nano-gpt.com/api/subscription/v1");
+    expect(provider.headers).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("omits Authorization from provider config so runtime auth can inject the real key", async () => {
@@ -298,8 +317,8 @@ describe("buildNanoGptProvider", () => {
     const provider = await buildNanoGptProvider({
       apiKey: "NANOGPT_API_KEY",
       pluginConfig: {
-        routingMode: "subscription",
-        catalogSource: "subscription",
+        routingMode: "paygo",
+        catalogSource: "canonical",
         provider: "openrouter",
       },
     });
@@ -308,7 +327,6 @@ describe("buildNanoGptProvider", () => {
 
     expect(provider.apiKey).toBe("NANOGPT_API_KEY");
     expect(provider.headers).toEqual({
-      "X-Billing-Mode": "paygo",
       "X-Provider": "openrouter",
     });
     expect(serializedProvider).not.toContain("Authorization");

--- a/provider-catalog.ts
+++ b/provider-catalog.ts
@@ -14,6 +14,7 @@ import {
   resolveCatalogSource,
   resolveNanoGptRequestApi,
   resolveNanoGptRoutingMode,
+  resolveNanoGptSelectedProvider,
   resolveRequestBaseUrl,
 } from "./runtime.js";
 
@@ -235,10 +236,14 @@ export async function buildNanoGptProvider(params: {
     config,
     routingMode,
   });
+  const selectedProvider = resolveNanoGptSelectedProvider({
+    config,
+    routingMode,
+  });
   const models = await discoverNanoGptModels({
     apiKey: params.apiKey,
     source: catalogSource,
-    provider: config.provider,
+    provider: selectedProvider,
   });
 
   const resolvedHeaders = buildNanoGptRequestHeaders({

--- a/runtime.test.ts
+++ b/runtime.test.ts
@@ -226,16 +226,15 @@ describe("resolveRequestBaseUrl", () => {
 });
 
 describe("buildNanoGptRequestHeaders", () => {
-  it("adds provider override and billing override for subscription routing", () => {
+  it("adds provider override headers for paygo routing", () => {
     expect(
       buildNanoGptRequestHeaders({
         apiKey: "test-key",
         config: { provider: "openrouter" },
-        routingMode: "subscription",
+        routingMode: "paygo",
       }),
     ).toEqual({
       Authorization: "Bearer test-key",
-      "X-Billing-Mode": "paygo",
       "X-Provider": "openrouter",
     });
   });
@@ -245,16 +244,27 @@ describe("buildNanoGptRequestHeaders", () => {
       buildNanoGptRequestHeaders({
         apiKey: "test-key\r\nInjected: true",
         config: { provider: "openrouter\r\nInjected: true" },
-        routingMode: "subscription",
+        routingMode: "paygo",
       }),
     ).toEqual({
       Authorization: "Bearer test-keyInjected: true",
-      "X-Billing-Mode": "paygo",
       "X-Provider": "openrouterInjected: true",
     });
   });
 
-  it("does not set a paygo billing override when no provider override is configured", () => {
+  it("ignores provider override during subscription routing", () => {
+    expect(
+      buildNanoGptRequestHeaders({
+        apiKey: "test-key",
+        config: { provider: "openrouter" },
+        routingMode: "subscription",
+      }),
+    ).toEqual({
+      Authorization: "Bearer test-key",
+    });
+  });
+
+  it("does not add extra headers when no provider override is configured", () => {
     expect(
       buildNanoGptRequestHeaders({
         apiKey: "test-key",

--- a/runtime.ts
+++ b/runtime.ts
@@ -458,6 +458,13 @@ export function resolveRequestBaseUrl(params: {
   return params.routingMode === "subscription" ? NANOGPT_SUBSCRIPTION_BASE_URL : NANOGPT_BASE_URL;
 }
 
+export function resolveNanoGptSelectedProvider(params: {
+  config: NanoGptPluginConfig;
+  routingMode: Exclude<NanoGptRoutingMode, "auto">;
+}): string | undefined {
+  return params.routingMode === "paygo" ? params.config.provider : undefined;
+}
+
 export async function discoverNanoGptModels(params: {
   apiKey: string;
   source: Exclude<NanoGptCatalogSource, "auto">;
@@ -622,11 +629,9 @@ export function buildNanoGptRequestHeaders(params: {
     Authorization: `Bearer ${sanitizeApiKey(params.apiKey)}`,
   };
 
-  if (params.config.provider) {
-    headers["X-Provider"] = sanitizeHeaderValue(params.config.provider);
-    if (params.routingMode === "subscription") {
-      headers["X-Billing-Mode"] = "paygo";
-    }
+  const provider = resolveNanoGptSelectedProvider(params);
+  if (provider) {
+    headers["X-Provider"] = sanitizeHeaderValue(provider);
   }
 
   return headers;


### PR DESCRIPTION
## Summary
- treat NanoGPT `provider` overrides as paygo-only instead of injecting them into subscription-routed text requests
- stop applying selected-provider pricing during subscription catalog builds so exposed model costs match the actual request path
- update runtime, catalog, discovery, and README coverage to reflect the corrected billing behavior

## Why
Issue #76 reported billing failures even for subscription users. The plugin was still carrying `provider` selection through subscription routing, which could push requests onto a separate billed path and trigger billing errors. The plugin metadata already described `provider` as paygo provider selection, so this change aligns the implementation with that contract.

Closes #76.

## Validation
- `npm test -- runtime.test.ts provider-catalog.test.ts openclaw-discovery.test.ts`
- `npm test`
- `npm run typecheck`