### PR TITLE
Align streaming usage compat with OpenClaw semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ For example:
 - `requestApi: "responses"` uses OpenAI Responses transport (experimental, requires models compatible with Responses API).
 - `requestApi: "completions"` keeps OpenAI Chat Completions transport.
 - `requestApi: "auto"` defaults to Completions for broader model compatibility; set to `"responses"` explicitly if your models support the Responses API.
-- Completions-mode models are still marked with streaming usage compatibility so
-  OpenClaw requests `stream_options.include_usage` automatically.
+- Completions-mode models with no explicit streaming-usage compat flag are
+  marked with streaming usage compatibility so OpenClaw requests
+  `stream_options.include_usage` automatically.
 - `moonshotai/kimi*` models keep tool support enabled and get extra reliability
   handling in the stream wrapper:
   - malformed tool-call argument JSON repair

--- a/index.test.ts
+++ b/index.test.ts
@@ -188,7 +188,7 @@ describe("nanogpt plugin entry", () => {
     );
   });
 
-  it("opts NanoGPT completions models into streaming usage compatibility", () => {
+  it("fills missing streaming usage compat without clobbering explicit false", () => {
     const provider = getRegisteredProvider();
     const applyCompat = provider.applyNativeStreamingUsageCompat;
     expect(applyCompat).toEqual(expect.any(Function));
@@ -204,6 +204,7 @@ describe("nanogpt plugin entry", () => {
           },
           {
             id: "gpt-5.4-mini",
+            compat: { supportsUsageInStreaming: false },
           },
         ],
       },
@@ -216,7 +217,32 @@ describe("nanogpt plugin entry", () => {
       supportsDeveloperRole: false,
       supportsUsageInStreaming: true,
     });
-    expect(result?.models[1]?.compat?.supportsUsageInStreaming).toBe(true);
+    expect(result?.models[1]?.compat?.supportsUsageInStreaming).toBe(false);
+  });
+
+  it("returns no compat patch when completions models already declare streaming usage support", () => {
+    const provider = getRegisteredProvider();
+    const applyCompat = provider.applyNativeStreamingUsageCompat;
+    expect(applyCompat).toEqual(expect.any(Function));
+
+    const result = applyCompat?.({
+      providerConfig: {
+        api: "openai-completions",
+        baseUrl: "https://nano-gpt.com/api/subscription/v1",
+        models: [
+          {
+            id: "moonshotai/kimi-k2.5:thinking",
+            compat: { supportsUsageInStreaming: true },
+          },
+          {
+            id: "gpt-5.4-mini",
+            compat: { supportsUsageInStreaming: false },
+          },
+        ],
+      },
+    });
+
+    expect(result).toBeNull();
   });
 
   it("opts in any completions config and skips non-completions APIs", () => {

--- a/index.ts
+++ b/index.ts
@@ -145,7 +145,7 @@ function applyNanoGptNativeStreamingUsageCompat(
 
   let changed = false;
   const models = providerConfig.models.map((model) => {
-    if (model.compat?.supportsUsageInStreaming === true) {
+    if (model.compat?.supportsUsageInStreaming !== undefined) {
       return model;
     }
     changed = true;


### PR DESCRIPTION
## Summary
- preserve explicit `supportsUsageInStreaming` values in the NanoGPT completions compat hook
- only fill `supportsUsageInStreaming: true` when the compat flag is currently undefined
- update the README behavior note to match the current semantics

## Validation
- `npm test`
- `npm run typecheck`

Fixes #64