### PR TITLE
Provision NanoGPT web_search auth during onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ The same key is used for:
 - NanoGPT web search
 - NanoGPT image generation
 
-The plugin reads `NANOGPT_API_KEY` by default. Web search can also use a
-dedicated config credential path described below.
+When you onboard NanoGPT auth with `openclaw onboard --nanogpt-api-key ...`
+or the interactive NanoGPT provider setup, the plugin also provisions the
+NanoGPT web-search credential path so the same auth works for text,
+`web_search`, and image generation. The plugin reads `NANOGPT_API_KEY` by
+default, and you can still override web search explicitly with the dedicated
+credential path described below.
 
 ## Text provider configuration
 
@@ -247,6 +251,8 @@ direct `POST /api/web` endpoint.
 Web search resolves credentials in this order:
 
 - `plugins.entries.nanogpt.config.webSearch.apiKey`
+  - normal NanoGPT auth/onboarding now provisions this path automatically
+  - you can still set it manually if you want a dedicated web-search override
 - `NANOGPT_API_KEY`
 
 `plugins.entries.nanogpt.config.webSearch.apiKey` is the web-search provider's

--- a/index.test.ts
+++ b/index.test.ts
@@ -741,6 +741,100 @@ describe("nanogpt plugin entry", () => {
     expect((result as { agents?: { defaults?: { model?: unknown } } })?.agents?.defaults?.model).toBeUndefined();
   });
 
+  it("mirrors interactive NanoGPT auth into the web search credential path", async () => {
+    const provider = getRegisteredProviderWithAuth();
+    const authMethod = provider.auth?.[0] as
+      | {
+          run?: (ctx: Record<string, unknown>) => Promise<Record<string, unknown>>;
+        }
+      | undefined;
+
+    expect(authMethod?.run).toEqual(expect.any(Function));
+
+    const result = await authMethod?.run?.({
+      opts: {
+        nanogptApiKey: "ngpt_interactive_key",
+      },
+      config: {},
+      env: {},
+      agentDir: "/tmp/nanogpt-agent",
+      runtime: {},
+      prompter: {
+        note: vi.fn(),
+        select: vi.fn(),
+        input: vi.fn(),
+        secret: vi.fn(),
+        confirm: vi.fn(),
+      },
+      secretInputMode: "plaintext",
+      allowSecretRefPrompt: false,
+      isRemote: false,
+      openUrl: async () => {},
+      oauth: {
+        createVpsAwareHandlers: vi.fn(),
+      },
+    });
+
+    expect(result).toMatchObject({
+      configPatch: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: "ngpt_interactive_key",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("mirrors non-interactive NanoGPT auth into the web search credential path", async () => {
+    const provider = getRegisteredProviderWithAuth();
+    const authMethod = provider.auth?.[0];
+
+    expect(authMethod?.runNonInteractive).toEqual(expect.any(Function));
+
+    const result = await authMethod?.runNonInteractive?.({
+      authChoice: "nanogpt-api-key",
+      opts: {
+        nanogptApiKey: "ngpt_live_key",
+      },
+      config: {},
+      baseConfig: {},
+      runtime: {} as never,
+      agentDir: "/tmp/nanogpt-agent",
+      resolveApiKey: async () => ({
+        key: "ngpt_live_key",
+        source: "flag",
+      }),
+      toApiKeyCredential: ({ resolved }: { resolved: { key: string } }) => ({
+        type: "api_key",
+        provider: "nanogpt",
+        key: resolved.key,
+      }),
+    } as never);
+
+    expect(result).toMatchObject({
+      plugins: {
+        entries: {
+          nanogpt: {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: "ngpt_live_key",
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
 
 
 

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { buildNanoGptImageGenerationProvider } from "./image-generation-provider.js";
-import { applyNanoGptProviderConfig } from "./onboard.js";
+import { applyNanoGptProviderAuthConfig, applyNanoGptProviderConfig } from "./onboard.js";
 import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
 import { buildNanoGptProvider, readNanoGptModelsJsonSnapshot } from "./provider-catalog.js";
 import {
@@ -37,6 +37,84 @@ type NanoGptCatalogEntry = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const NANOGPT_API_KEY_FLAG_NAME = "--nanogpt-api-key" as const;
+const NANOGPT_API_KEY_ENV_VAR = "NANOGPT_API_KEY" as const;
+const NANOGPT_API_KEY_OPTION_KEY = "nanogptApiKey" as const;
+
+type NanoGptApiKeyAuthMethod = ReturnType<typeof createProviderApiKeyAuthMethod>;
+type NanoGptApiKeyAuthContext = Parameters<NanoGptApiKeyAuthMethod["run"]>[0];
+type NanoGptApiKeyNonInteractiveContext = Parameters<
+  NonNullable<NanoGptApiKeyAuthMethod["runNonInteractive"]>
+>[0];
+
+function resolveNanoGptApiKeyOptionValue(ctx: NanoGptApiKeyNonInteractiveContext): string | undefined {
+  const opts = ctx.opts as Record<string, unknown> | undefined;
+  return typeof opts?.[NANOGPT_API_KEY_OPTION_KEY] === "string"
+    ? opts[NANOGPT_API_KEY_OPTION_KEY]
+    : undefined;
+}
+
+function createNanoGptApiKeyAuthMethod(): NanoGptApiKeyAuthMethod {
+  const baseMethod = createProviderApiKeyAuthMethod({
+    providerId: NANOGPT_PROVIDER_ID,
+    methodId: "api-key",
+    label: "NanoGPT API key",
+    hint: "Subscription or pay-as-you-go",
+    optionKey: NANOGPT_API_KEY_OPTION_KEY,
+    flagName: NANOGPT_API_KEY_FLAG_NAME,
+    envVar: NANOGPT_API_KEY_ENV_VAR,
+    promptMessage: "Enter NanoGPT API key",
+    expectedProviders: [NANOGPT_PROVIDER_ID],
+    applyConfig: (cfg) => applyNanoGptProviderConfig(cfg),
+    wizard: {
+      choiceId: "nanogpt-api-key",
+      choiceLabel: "NanoGPT API key",
+      groupId: "nanogpt",
+      groupLabel: "NanoGPT",
+      groupHint: "Subscription or pay-as-you-go",
+    },
+  });
+  const runNonInteractive = baseMethod.runNonInteractive;
+
+  return {
+    ...baseMethod,
+    run: async (ctx: NanoGptApiKeyAuthContext) => {
+      const result = await baseMethod.run(ctx);
+      return {
+        ...result,
+        configPatch: applyNanoGptProviderAuthConfig(
+          result.configPatch ?? ctx.config,
+          result.profiles[0]?.credential,
+        ),
+      };
+    },
+    runNonInteractive: runNonInteractive
+      ? async (ctx: NanoGptApiKeyNonInteractiveContext) => {
+          const next = await runNonInteractive(ctx);
+          if (!next) {
+            return next;
+          }
+
+          const resolved = await ctx.resolveApiKey({
+            provider: NANOGPT_PROVIDER_ID,
+            flagValue: resolveNanoGptApiKeyOptionValue(ctx),
+            flagName: NANOGPT_API_KEY_FLAG_NAME,
+            envVar: NANOGPT_API_KEY_ENV_VAR,
+          });
+          if (!resolved || resolved.source === "profile") {
+            return next;
+          }
+
+          const credential = ctx.toApiKeyCredential({
+            provider: NANOGPT_PROVIDER_ID,
+            resolved,
+          });
+          return credential ? applyNanoGptProviderAuthConfig(next, credential) : next;
+        }
+      : undefined,
+  };
 }
 
 function mergeNanoGptCatalogEntries(...groups: NanoGptCatalogEntry[][]): NanoGptCatalogEntry[] {
@@ -247,27 +325,7 @@ export default definePluginEntry({
       label: "NanoGPT",
       docsPath: "/providers/models",
       envVars: ["NANOGPT_API_KEY"],
-      auth: [
-        createProviderApiKeyAuthMethod({
-          providerId: NANOGPT_PROVIDER_ID,
-          methodId: "api-key",
-          label: "NanoGPT API key",
-          hint: "Subscription or pay-as-you-go",
-          optionKey: "nanogptApiKey",
-          flagName: "--nanogpt-api-key",
-          envVar: "NANOGPT_API_KEY",
-          promptMessage: "Enter NanoGPT API key",
-          expectedProviders: [NANOGPT_PROVIDER_ID],
-          applyConfig: (cfg) => applyNanoGptProviderConfig(cfg),
-          wizard: {
-            choiceId: "nanogpt-api-key",
-            choiceLabel: "NanoGPT API key",
-            groupId: "nanogpt",
-            groupLabel: "NanoGPT",
-            groupHint: "Subscription or pay-as-you-go",
-          },
-        }),
-      ],
+      auth: [createNanoGptApiKeyAuthMethod()],
       catalog: {
         order: "simple",
         run: async (ctx: ProviderCatalogContext) => {

--- a/onboard.test.ts
+++ b/onboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applyNanoGptConfig,
+  applyNanoGptProviderAuthConfig,
   applyNanoGptProviderConfig,
 } from "./onboard.js";
 
@@ -26,6 +27,46 @@ describe("NanoGPT onboarding helpers", () => {
     });
     expect(next.agents?.defaults?.model).toMatchObject({
       primary: "nanogpt/gpt-5.4-mini",
+    });
+  });
+
+  it("provisions the NanoGPT web_search credential path from auth credentials", () => {
+    const next = applyNanoGptProviderAuthConfig({}, {
+      type: "api_key",
+      provider: "nanogpt",
+      key: "ngpt_test_key",
+    });
+
+    expect(next.plugins?.entries?.nanogpt).toMatchObject({
+      enabled: true,
+      config: {
+        webSearch: {
+          apiKey: "ngpt_test_key",
+        },
+      },
+    });
+    expect(next.agents?.defaults?.models).toMatchObject({
+      "nanogpt/gpt-5.4-mini": {
+        alias: "NanoGPT",
+      },
+    });
+  });
+
+  it("keeps env secret refs portable when provisioning NanoGPT web_search auth", () => {
+    const next = applyNanoGptProviderAuthConfig({}, {
+      type: "api_key",
+      provider: "nanogpt",
+      keyRef: {
+        source: "env",
+        provider: "default",
+        id: "NANOGPT_API_KEY",
+      },
+    });
+
+    expect(next.plugins?.entries?.nanogpt?.config).toMatchObject({
+      webSearch: {
+        apiKey: "${NANOGPT_API_KEY}",
+      },
     });
   });
 });

--- a/onboard.ts
+++ b/onboard.ts
@@ -2,7 +2,76 @@ import {
   applyAgentDefaultModelPrimary,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
-import { NANOGPT_DEFAULT_MODEL_REF } from "./models.js";
+import { setProviderWebSearchPluginConfigValue } from "openclaw/plugin-sdk/provider-web-search";
+import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeNanoGptConfiguredCredentialValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const source = typeof value.source === "string" ? value.source.trim().toLowerCase() : "";
+  const id = typeof value.id === "string" ? value.id.trim() : "";
+  if (source === "env" && id) {
+    return `\${${id}}`;
+  }
+
+  return value;
+}
+
+function cloneNanoGptPluginEntry(cfg: OpenClawConfig): OpenClawConfig {
+  const existingEntry = cfg.plugins?.entries?.[NANOGPT_PROVIDER_ID];
+  const entry = isRecord(existingEntry) ? existingEntry : undefined;
+  const entryConfig = isRecord(entry?.config) ? entry.config : undefined;
+  const webSearchConfig = isRecord(entryConfig?.webSearch) ? entryConfig.webSearch : undefined;
+
+  return {
+    ...cfg,
+    plugins: {
+      ...cfg.plugins,
+      entries: {
+        ...cfg.plugins?.entries,
+        ...(entry
+          ? {
+              [NANOGPT_PROVIDER_ID]: {
+                ...entry,
+                ...(entryConfig
+                  ? {
+                      config: {
+                        ...entryConfig,
+                        ...(webSearchConfig ? { webSearch: { ...webSearchConfig } } : {}),
+                      },
+                    }
+                  : {}),
+              },
+            }
+          : {}),
+      },
+    },
+  };
+}
+
+export function resolveNanoGptWebSearchCredentialValue(credential: unknown): unknown {
+  if (!isRecord(credential)) {
+    return undefined;
+  }
+
+  const key = normalizeNanoGptConfiguredCredentialValue(credential.key);
+  if (key !== undefined) {
+    return key;
+  }
+
+  return normalizeNanoGptConfiguredCredentialValue(credential.keyRef);
+}
 
 export function applyNanoGptProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
@@ -21,6 +90,26 @@ export function applyNanoGptProviderConfig(cfg: OpenClawConfig): OpenClawConfig 
       },
     },
   };
+}
+
+export function applyNanoGptProviderAuthConfig(
+  cfg: OpenClawConfig,
+  credential?: unknown,
+): OpenClawConfig {
+  const next = applyNanoGptProviderConfig(cfg);
+  const value = resolveNanoGptWebSearchCredentialValue(credential);
+  if (value === undefined) {
+    return next;
+  }
+
+  const configWithClonedPluginEntry = cloneNanoGptPluginEntry(next);
+  setProviderWebSearchPluginConfigValue(
+    configWithClonedPluginEntry,
+    NANOGPT_PROVIDER_ID,
+    "apiKey",
+    value,
+  );
+  return configWithClonedPluginEntry;
 }
 
 export function applyNanoGptConfig(cfg: OpenClawConfig): OpenClawConfig {

--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -161,6 +161,97 @@ describe("nanogpt web search provider", () => {
       ],
     });
   });
+
+  it("prefers the dedicated NanoGPT web_search credential over NANOGPT_API_KEY", async () => {
+    process.env.NANOGPT_API_KEY = "env-key";
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [], metadata: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "config-key",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({ query: "nanogpt docs" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({
+      headers: {
+        Authorization: "Bearer config-key",
+      },
+    });
+  });
+
+  it("resolves env secret refs from the provisioned NanoGPT web_search credential path", async () => {
+    process.env.NANOGPT_API_KEY = "env-ref-key";
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [],
+          metadata: {
+            query: "nanogpt docs",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "${NANOGPT_API_KEY}",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({ query: "nanogpt docs" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({
+      headers: {
+        Authorization: "Bearer env-ref-key",
+      },
+    });
+  });
+
   it("filters out results with unsafe or invalid URLs", () => {
     expect(
       __testing.normalizeNanoGptWebSearchResult({

--- a/web-search.ts
+++ b/web-search.ts
@@ -1,7 +1,10 @@
+import { NANOGPT_PROVIDER_ID } from "./models.js";
 import { NANOGPT_WEB_SEARCH_TIMEOUT_MS, sanitizeApiKey } from "./runtime.js";
 import {
   enablePluginInConfig,
+  mergeScopedSearchConfig,
   readNumberParam,
+  readConfiguredSecretString,
   readProviderEnvValue,
   readStringArrayParam,
   readStringParam,
@@ -66,17 +69,34 @@ type NanoGptWebSearchResponse = {
   };
 };
 
-function resolveNanoGptWebSearchApiKey(config?: Record<string, unknown>): string | undefined {
-  const pluginConfig = resolveProviderWebSearchPluginConfig(
-    config as Parameters<typeof resolveProviderWebSearchPluginConfig>[0],
-    "nanogpt",
-  );
-  const apiKey = typeof pluginConfig?.apiKey === "string" ? pluginConfig.apiKey.trim() : "";
-  if (apiKey) {
-    return apiKey;
-  }
+const NANOGPT_ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
 
-  return readProviderEnvValue(["NANOGPT_API_KEY"]);
+function resolveNanoGptWebSearchConfig(ctx: {
+  config?: Record<string, unknown>;
+  searchConfig?: Record<string, unknown>;
+}): Record<string, unknown> | undefined {
+  return mergeScopedSearchConfig(
+    ctx.searchConfig,
+    NANOGPT_PROVIDER_ID,
+    resolveProviderWebSearchPluginConfig(
+      ctx.config as Parameters<typeof resolveProviderWebSearchPluginConfig>[0],
+      NANOGPT_PROVIDER_ID,
+    ),
+    { mirrorApiKeyToTopLevel: true },
+  );
+}
+
+function resolveNanoGptWebSearchApiKey(searchConfig?: Record<string, unknown>): string | undefined {
+  const inlineEnvRef =
+    typeof searchConfig?.apiKey === "string"
+      ? NANOGPT_ENV_REF_PATTERN.exec(searchConfig.apiKey.trim())?.[1]
+      : undefined;
+
+  return (
+    (inlineEnvRef ? readProviderEnvValue([inlineEnvRef]) : undefined) ??
+    readConfiguredSecretString(searchConfig?.apiKey, "tools.web.search.apiKey") ??
+    readProviderEnvValue(["NANOGPT_API_KEY"])
+  );
 }
 
 function normalizeNanoGptWebSearchResult(
@@ -142,7 +162,7 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
     inactiveSecretPaths: ["plugins.entries.nanogpt.config.webSearch.apiKey"],
     getCredentialValue: (searchConfig: unknown) => {
       const cfg = searchConfig as Record<string, unknown> | undefined;
-      return typeof cfg?.apiKey === "string" ? cfg.apiKey : undefined;
+      return cfg?.apiKey;
     },
     setCredentialValue: () => {},
     getConfiguredCredentialValue: (config) =>
@@ -156,7 +176,11 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         "Search the web using NanoGPT's direct web search API. Returns titles, URLs, and snippets.",
       parameters: NANOGPT_WEB_SEARCH_SCHEMA,
       execute: async (args) => {
-        const apiKey = resolveNanoGptWebSearchApiKey(ctx.config as Record<string, unknown>);
+        const searchConfig = resolveNanoGptWebSearchConfig({
+          config: ctx.config as Record<string, unknown> | undefined,
+          searchConfig: ctx.searchConfig as Record<string, unknown> | undefined,
+        });
+        const apiKey = resolveNanoGptWebSearchApiKey(searchConfig);
         if (!apiKey) {
           return missingNanoGptKeyPayload();
         }


### PR DESCRIPTION
## Summary
- provision NanoGPT auth/onboarding into the plugin's `web_search` credential path
- make NanoGPT web search resolve merged scoped config and `${NANOGPT_API_KEY}` env refs correctly
- add regression coverage for interactive and non-interactive auth provisioning plus credential precedence
- update the README so the documented NanoGPT auth behavior matches the implementation

Fixes #65

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`