### PR TITLE
Adopt OpenClaw helpers for NanoGPT web_search

### DIFF
--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -1,4 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { postTrustedWebToolsJsonMock } = vi.hoisted(() => ({
+  postTrustedWebToolsJsonMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-web-search")>(
+    "openclaw/plugin-sdk/provider-web-search",
+  );
+  return {
+    ...actual,
+    postTrustedWebToolsJson: postTrustedWebToolsJsonMock,
+  };
+});
+
 import plugin from "./index.js";
 import { clearEnvKeys, restoreEnv, snapshotEnv } from "./test-env.js";
 import { createNanoGptWebSearchProvider, __testing } from "./web-search.js";
@@ -10,6 +25,7 @@ let webSearchEnvSnapshot: Record<string, string | undefined> | undefined;
 beforeEach(() => {
   webSearchEnvSnapshot = snapshotEnv(WEB_SEARCH_ENV_KEYS);
   clearEnvKeys(WEB_SEARCH_ENV_KEYS);
+  postTrustedWebToolsJsonMock.mockReset();
 });
 
 describe("nanogpt web search provider", () => {
@@ -34,6 +50,35 @@ describe("nanogpt web search provider", () => {
     });
   });
 
+  it("round-trips credentials through the normal provider contract fields", () => {
+    const provider = createNanoGptWebSearchProvider();
+    const searchConfig: Record<string, unknown> = {};
+    const config: Record<string, unknown> = {};
+
+    provider.setCredentialValue(searchConfig, "top-level-key");
+    provider.setConfiguredCredentialValue?.(config as never, "configured-key");
+
+    expect(provider.getCredentialValue(searchConfig)).toBe("top-level-key");
+    expect(provider.getConfiguredCredentialValue?.(config as never)).toBe("configured-key");
+    expect(searchConfig).toMatchObject({
+      apiKey: "top-level-key",
+    });
+    expect(config).toMatchObject({
+      plugins: {
+        entries: {
+          nanogpt: {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: "configured-key",
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("returns a missing-key payload when no NanoGPT key is configured", async () => {
     const provider = createNanoGptWebSearchProvider();
     const tool = provider.createTool({
@@ -47,6 +92,7 @@ describe("nanogpt web search provider", () => {
     await expect(tool.execute({ query: "nanogpt docs" })).resolves.toMatchObject({
       error: "missing_nanogpt_api_key",
     });
+    expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
   });
 
   it("rejects search queries that exceed the maximum length", async () => {
@@ -75,34 +121,40 @@ describe("nanogpt web search provider", () => {
     await expect(tool.execute({ query: longQuery })).rejects.toThrow(
       "Search query is too long (maximum 2000 characters)."
     );
+    expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
   });
 
-  it("normalizes NanoGPT search results and forwards domain filters", async () => {
-    const fetchSpy = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          data: [
+  it("normalizes NanoGPT search results and forwards domain filters through the trusted helper", async () => {
+    postTrustedWebToolsJsonMock.mockImplementation(
+      async (
+        params: Record<string, unknown>,
+        parseResponse: (response: Response) => Promise<unknown>,
+      ) =>
+        await parseResponse(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  title: "NanoGPT Docs",
+                  url: "https://docs.nano-gpt.com/",
+                  snippet: "API reference and integration guides.",
+                },
+              ],
+              metadata: {
+                query: "nanogpt docs",
+                provider: "linkup",
+                depth: "standard",
+                outputType: "searchResults",
+                cost: 0.006,
+              },
+            }),
             {
-              title: "NanoGPT Docs",
-              url: "https://docs.nano-gpt.com/",
-              snippet: "API reference and integration guides.",
+              status: 200,
+              headers: { "Content-Type": "application/json" },
             },
-          ],
-          metadata: {
-            query: "nanogpt docs",
-            provider: "linkup",
-            depth: "standard",
-            outputType: "searchResults",
-            cost: 0.006,
-          },
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      ),
+          ),
+        ),
     );
-    vi.stubGlobal("fetch", fetchSpy);
 
     const provider = createNanoGptWebSearchProvider();
     const tool = provider.createTool({
@@ -131,23 +183,20 @@ describe("nanogpt web search provider", () => {
       excludeDomains: ["example.com"],
     });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://nano-gpt.com/api/web");
-    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({
-      method: "POST",
-      headers: {
-        Authorization: "Bearer test-key",
-        "Content-Type": "application/json",
-        Accept: "application/json",
+    expect(postTrustedWebToolsJsonMock).toHaveBeenCalledTimes(1);
+    expect(postTrustedWebToolsJsonMock.mock.calls[0]?.[0]).toMatchObject({
+      url: "https://nano-gpt.com/api/web",
+      apiKey: "test-key",
+      timeoutSeconds: 30,
+      errorLabel: "NanoGPT web search",
+      body: {
+        query: "nanogpt docs",
+        provider: "linkup",
+        depth: "standard",
+        outputType: "searchResults",
+        includeDomains: ["docs.nano-gpt.com"],
+        excludeDomains: ["example.com"],
       },
-    });
-    expect(JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body))).toMatchObject({
-      query: "nanogpt docs",
-      provider: "linkup",
-      depth: "standard",
-      outputType: "searchResults",
-      includeDomains: ["docs.nano-gpt.com"],
-      excludeDomains: ["example.com"],
     });
     expect(result).toMatchObject({
       query: "nanogpt docs",
@@ -164,13 +213,22 @@ describe("nanogpt web search provider", () => {
 
   it("prefers the dedicated NanoGPT web_search credential over NANOGPT_API_KEY", async () => {
     process.env.NANOGPT_API_KEY = "env-key";
-    const fetchSpy = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: [], metadata: {} }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+    postTrustedWebToolsJsonMock.mockImplementation(
+      async (
+        params: Record<string, unknown>,
+        parseResponse: (response: Response) => Promise<unknown>,
+      ) => {
+        expect(params).toMatchObject({
+          apiKey: "config-key",
+        });
+        return await parseResponse(
+          new Response(JSON.stringify({ data: [], metadata: {} }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      },
     );
-    vi.stubGlobal("fetch", fetchSpy);
 
     const provider = createNanoGptWebSearchProvider();
     const tool = provider.createTool({
@@ -194,32 +252,80 @@ describe("nanogpt web search provider", () => {
     }
 
     await tool.execute({ query: "nanogpt docs" });
+    expect(postTrustedWebToolsJsonMock).toHaveBeenCalledTimes(1);
+  });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({
-      headers: {
-        Authorization: "Bearer config-key",
+  it("prefers the configured NanoGPT credential over a top-level search apiKey", async () => {
+    postTrustedWebToolsJsonMock.mockImplementation(
+      async (
+        params: Record<string, unknown>,
+        parseResponse: (response: Response) => Promise<unknown>,
+      ) => {
+        expect(params).toMatchObject({
+          apiKey: "configured-key",
+        });
+        return await parseResponse(
+          new Response(JSON.stringify({ data: [], metadata: {} }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
       },
-    });
+    );
+
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "configured-key",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {
+        apiKey: "top-level-key",
+      },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({ query: "nanogpt docs" });
+    expect(postTrustedWebToolsJsonMock).toHaveBeenCalledTimes(1);
   });
 
   it("resolves env secret refs from the provisioned NanoGPT web_search credential path", async () => {
     process.env.NANOGPT_API_KEY = "env-ref-key";
-    const fetchSpy = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          data: [],
-          metadata: {
-            query: "nanogpt docs",
-          },
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      ),
+    postTrustedWebToolsJsonMock.mockImplementation(
+      async (
+        params: Record<string, unknown>,
+        parseResponse: (response: Response) => Promise<unknown>,
+      ) => {
+        expect(params).toMatchObject({
+          apiKey: "env-ref-key",
+        });
+        return await parseResponse(
+          new Response(
+            JSON.stringify({
+              data: [],
+              metadata: {
+                query: "nanogpt docs",
+              },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      },
     );
-    vi.stubGlobal("fetch", fetchSpy);
 
     const provider = createNanoGptWebSearchProvider();
     const tool = provider.createTool({
@@ -243,13 +349,7 @@ describe("nanogpt web search provider", () => {
     }
 
     await tool.execute({ query: "nanogpt docs" });
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy.mock.calls[0]?.[1]).toMatchObject({
-      headers: {
-        Authorization: "Bearer env-ref-key",
-      },
-    });
+    expect(postTrustedWebToolsJsonMock).toHaveBeenCalledTimes(1);
   });
 
   it("filters out results with unsafe or invalid URLs", () => {

--- a/web-search.ts
+++ b/web-search.ts
@@ -1,22 +1,25 @@
 import { NANOGPT_PROVIDER_ID } from "./models.js";
-import { NANOGPT_WEB_SEARCH_TIMEOUT_MS, sanitizeApiKey } from "./runtime.js";
+import { sanitizeApiKey } from "./runtime.js";
 import {
-  enablePluginInConfig,
   mergeScopedSearchConfig,
+  postTrustedWebToolsJson,
   readNumberParam,
-  readConfiguredSecretString,
   readProviderEnvValue,
   readStringArrayParam,
   readStringParam,
   resolveProviderWebSearchPluginConfig,
   resolveSearchCount,
+  resolveSearchTimeoutSeconds,
   resolveSiteName,
-  setProviderWebSearchPluginConfigValue,
+  resolveWebSearchProviderCredential,
   wrapWebContent,
   type WebSearchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-search";
+import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-contract";
 
 const NANOGPT_WEB_SEARCH_URL = "https://nano-gpt.com/api/web";
+const NANOGPT_WEB_SEARCH_CREDENTIAL_PATH = "plugins.entries.nanogpt.config.webSearch.apiKey";
+const NANOGPT_ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
 const NANOGPT_WEB_SEARCH_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -69,8 +72,6 @@ type NanoGptWebSearchResponse = {
   };
 };
 
-const NANOGPT_ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
-
 function resolveNanoGptWebSearchConfig(ctx: {
   config?: Record<string, unknown>;
   searchConfig?: Record<string, unknown>;
@@ -87,16 +88,20 @@ function resolveNanoGptWebSearchConfig(ctx: {
 }
 
 function resolveNanoGptWebSearchApiKey(searchConfig?: Record<string, unknown>): string | undefined {
+  // Keep compatibility with the ${ENV_VAR} string form provisioned by NanoGPT
+  // onboarding/auth setup. The generic helper handles direct strings and
+  // structured secret refs, but this legacy env-template form still needs to
+  // be collapsed before handing off to the normal provider credential path.
   const inlineEnvRef =
     typeof searchConfig?.apiKey === "string"
       ? NANOGPT_ENV_REF_PATTERN.exec(searchConfig.apiKey.trim())?.[1]
       : undefined;
 
-  return (
-    (inlineEnvRef ? readProviderEnvValue([inlineEnvRef]) : undefined) ??
-    readConfiguredSecretString(searchConfig?.apiKey, "tools.web.search.apiKey") ??
-    readProviderEnvValue(["NANOGPT_API_KEY"])
-  );
+  return resolveWebSearchProviderCredential({
+    credentialValue: (inlineEnvRef ? readProviderEnvValue([inlineEnvRef]) : undefined) ?? searchConfig?.apiKey,
+    path: "tools.web.search.apiKey",
+    envVars: ["NANOGPT_API_KEY"],
+  });
 }
 
 function normalizeNanoGptWebSearchResult(
@@ -141,7 +146,7 @@ function missingNanoGptKeyPayload() {
   return {
     error: "missing_nanogpt_api_key",
     message:
-      "web_search (nanogpt) needs NANOGPT_API_KEY. Set it in the environment or store it under plugins.entries.nanogpt.config.webSearch.apiKey.",
+      "web_search (nanogpt) needs a NanoGPT API key. Set tools.web.search.apiKey, set NANOGPT_API_KEY in the environment, or store it under plugins.entries.nanogpt.config.webSearch.apiKey.",
     docs: "https://docs.nano-gpt.com/api-reference/endpoint/web-search",
   };
 }
@@ -158,19 +163,17 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://nano-gpt.com/api",
     docsUrl: "https://docs.nano-gpt.com/api-reference/endpoint/web-search",
     autoDetectOrder: 60,
-    credentialPath: "plugins.entries.nanogpt.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.nanogpt.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig: unknown) => {
-      const cfg = searchConfig as Record<string, unknown> | undefined;
-      return cfg?.apiKey;
-    },
-    setCredentialValue: () => {},
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "nanogpt")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "nanogpt", "apiKey", value);
-    },
-    applySelectionConfig: (config) => enablePluginInConfig(config, "nanogpt").config,
+    credentialPath: NANOGPT_WEB_SEARCH_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: NANOGPT_WEB_SEARCH_CREDENTIAL_PATH,
+      searchCredential: {
+        type: "top-level",
+      },
+      configuredCredential: {
+        pluginId: NANOGPT_PROVIDER_ID,
+      },
+      selectionPluginId: NANOGPT_PROVIDER_ID,
+    }),
     createTool: (ctx) => ({
       description:
         "Search the web using NanoGPT's direct web search API. Returns titles, URLs, and snippets.",
@@ -194,50 +197,43 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         const includeDomains = readStringArrayParam(args, "includeDomains")?.filter(Boolean);
         const excludeDomains = readStringArrayParam(args, "excludeDomains")?.filter(Boolean);
 
-        const response = await fetch(NANOGPT_WEB_SEARCH_URL, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${sanitizeApiKey(apiKey)}`,
-            "Content-Type": "application/json",
-            Accept: "application/json",
+        return await postTrustedWebToolsJson(
+          {
+            url: NANOGPT_WEB_SEARCH_URL,
+            apiKey: sanitizeApiKey(apiKey),
+            timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+            errorLabel: "NanoGPT web search",
+            body: {
+              query,
+              provider: "linkup",
+              depth: "standard",
+              outputType: "searchResults",
+              ...(includeDomains && includeDomains.length > 0 ? { includeDomains } : {}),
+              ...(excludeDomains && excludeDomains.length > 0 ? { excludeDomains } : {}),
+            },
           },
-          body: JSON.stringify({
-            query,
-            provider: "linkup",
-            depth: "standard",
-            outputType: "searchResults",
-            ...(includeDomains && includeDomains.length > 0 ? { includeDomains } : {}),
-            ...(excludeDomains && excludeDomains.length > 0 ? { excludeDomains } : {}),
-          }),
-          signal: AbortSignal.timeout(NANOGPT_WEB_SEARCH_TIMEOUT_MS),
-        });
+          async (response) => {
+            const payload = (await response.json()) as NanoGptWebSearchResponse;
+            const results = (Array.isArray(payload.data) ? payload.data : [])
+              .map(normalizeNanoGptWebSearchResult)
+              .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+              .slice(0, count);
 
-        if (!response.ok) {
-          const detail = await response.text();
-          throw new Error(
-            `NanoGPT web search failed (${response.status}): ${detail || response.statusText}`,
-          );
-        }
-
-        const payload = (await response.json()) as NanoGptWebSearchResponse;
-        const results = (Array.isArray(payload.data) ? payload.data : [])
-          .map(normalizeNanoGptWebSearchResult)
-          .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
-          .slice(0, count);
-
-        return {
-          query,
-          provider: "nanogpt",
-          count: results.length,
-          externalContent: {
-            untrusted: true,
-            source: "web_search",
-            provider: "nanogpt",
-            wrapped: true,
+            return {
+              query,
+              provider: "nanogpt",
+              count: results.length,
+              externalContent: {
+                untrusted: true,
+                source: "web_search",
+                provider: "nanogpt",
+                wrapped: true,
+              },
+              results,
+              metadata: payload.metadata ?? {},
+            };
           },
-          results,
-          metadata: payload.metadata ?? {},
-        };
+        );
       },
     }),
   };


### PR DESCRIPTION
## Summary
- move NanoGPT `web_search` onto OpenClaw's normal web-search contract fields
- replace raw NanoGPT search requests with the trusted web-tools JSON helper path
- keep `${NANOGPT_API_KEY}` compatibility for onboarded env-ref configs while using the newer credential helper flow
- add regression coverage for contract round-tripping, helper usage, and credential precedence

Fixes #66

## Validation
- `npm test`
- `npm run typecheck`