### PR TITLE
Repair leaked XML-style Qwen tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,11 @@ For example:
   - best-effort salvage of structured tool payloads wrapped as assistant text
   - turns without tool definitions use the lighter live guard path instead of
     the full buffered collect/replay wrapper
-- `qwen/*thinking` models use the same buffered repair path as Kimi for
+- `qwen/*` models use the same buffered repair path as Kimi for
   malformed tool-call argument JSON, one-shot empty-turn retries, and
-  best-effort salvage of structured tool payloads wrapped as assistant text.
+  best-effort salvage of structured tool payloads wrapped as assistant text,
+  including XML-ish `<function=...><parameter=...>` payloads leaked as plain
+  assistant text.
 - `zai-org/glm*` models stay on the live malformed-tool-call guard path,
   emit semantic warnings when tool schemas look incomplete, and get light
   schema hints in `normalizeToolSchemas` to nudge required

--- a/repair.test.ts
+++ b/repair.test.ts
@@ -86,6 +86,16 @@ describe("resolveNanoGptRepairProfile", () => {
       },
     ],
     [
+      "nanogpt/qwen/Qwen3.6-35B-A3B",
+      {
+        family: "qwen",
+        useBufferedRepair: true,
+        useLiveGuard: true,
+        useSemanticToolDiagnostics: false,
+        useToolSchemaHints: false,
+      },
+    ],
+    [
       "nanogpt/qwen/qwen3.5-397b-a17b-thinking",
       {
         family: "qwen",
@@ -156,13 +166,15 @@ describe("resolveNanoGptRepairProfile", () => {
   });
 
 describe("shouldRepairNanoGptToolCallArguments", () => {
-  it("enables buffered repair for Kimi and Qwen thinking model ids", () => {
+  it("enables buffered repair for Kimi and Qwen model ids", () => {
     expect(shouldRepairNanoGptToolCallArguments("moonshotai/kimi-k2.5")).toBe(true);
     expect(shouldRepairNanoGptToolCallArguments("moonshotai/kimi-k2.5:thinking")).toBe(true);
     expect(shouldRepairNanoGptToolCallArguments("nanogpt/moonshotai/kimi-k2.5:thinking")).toBe(true);
+    expect(shouldRepairNanoGptToolCallArguments("qwen/Qwen3.6-35B-A3B")).toBe(true);
+    expect(shouldRepairNanoGptToolCallArguments("nanogpt/qwen/Qwen3.6-35B-A3B")).toBe(true);
     expect(shouldRepairNanoGptToolCallArguments("qwen/qwen3.5-397b-a17b-thinking")).toBe(true);
     expect(shouldRepairNanoGptToolCallArguments("nanogpt/qwen/qwen3.5-397b-a17b-thinking")).toBe(true);
-    expect(shouldRepairNanoGptToolCallArguments("qwen/qwen3.5-397b-a17b")).toBe(false);
+    expect(shouldRepairNanoGptToolCallArguments("qwen/qwen3.5-397b-a17b")).toBe(true);
     expect(shouldRepairNanoGptToolCallArguments("zai-org/glm-5:thinking")).toBe(false);
     expect(shouldRepairNanoGptToolCallArguments("nanogpt/zai-org/glm-5:thinking")).toBe(false);
     expect(shouldRepairNanoGptToolCallArguments("mistralai/mistral-large-3-675b-instruct-2512")).toBe(false);
@@ -680,18 +692,15 @@ describe("wrapStreamWithToolCallRepair", () => {
     );
   });
 
-  it("salvages structured tool payload text for Qwen thinking models", async () => {
-    const toolPayload = JSON.stringify({
-      tool_calls: [
-        {
-          name: "browser",
-          arguments: {
-            query: "NanoGPT Qwen tool repair",
-            count: 1,
-          },
-        },
-      ],
-    });
+  it("salvages XML-like function payload text for Qwen models", async () => {
+    const toolPayload = [
+      "<function=exec>",
+      "<parameter=command>",
+      "find /Users/openclaw/.openclaw/workspace-teleclaw -path \"*nanogpt*\" -type f 2>/dev/null",
+      "</parameter>",
+      "</execution>",
+      "</tool_call>",
+    ].join("\n");
 
     const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
       yield {
@@ -706,13 +715,13 @@ describe("wrapStreamWithToolCallRepair", () => {
     const logger = { warn: vi.fn(), info: vi.fn() };
     const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
     const resultStream = await wrapped(
-      { id: "qwen/qwen3.5-397b-a17b-thinking", api: "openai-completions" } as any,
+      { id: "qwen/Qwen3.6-35B-A3B", api: "openai-completions" } as any,
       {
         messages: [],
         tools: [
           {
-            name: "browser",
-            description: "Browser navigation tool",
+            name: "exec",
+            description: "Execute a shell command",
             parameters: { type: "object" },
           },
         ],
@@ -726,10 +735,10 @@ describe("wrapStreamWithToolCallRepair", () => {
       {
         type: "toolCall",
         id: "call_salvaged_1",
-        name: "browser",
+        name: "exec",
         arguments: {
-          query: "NanoGPT Qwen tool repair",
-          count: 1,
+          command:
+            "find /Users/openclaw/.openclaw/workspace-teleclaw -path \"*nanogpt*\" -type f 2>/dev/null",
         },
       },
     ]);

--- a/repair.ts
+++ b/repair.ts
@@ -84,8 +84,8 @@ function normalizeNanoGptRepairModelId(modelId: string): string {
   return normalized.startsWith("nanogpt/") ? normalized.slice("nanogpt/".length) : normalized;
 }
 
-function isQwenThinkingModel(normalizedModelId: string): boolean {
-  return normalizedModelId.startsWith("qwen/") && /(?:[:/-])thinking(?:$|[-/])/.test(normalizedModelId);
+function isQwenModel(normalizedModelId: string): boolean {
+  return normalizedModelId.startsWith("qwen/");
 }
 
 function resolveNanoGptRepairFamily(modelId?: string): NanoGptRepairFamily {
@@ -100,7 +100,7 @@ function resolveNanoGptRepairFamily(modelId?: string): NanoGptRepairFamily {
   if (normalized.startsWith("zai-org/glm")) {
     return "glm";
   }
-  if (isQwenThinkingModel(normalized)) {
+  if (isQwenModel(normalized)) {
     return "qwen";
   }
   return "other";
@@ -493,11 +493,149 @@ function extractPseudoToolWrapperName(attributes: string): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+type XmlParameterBlock = {
+  name: string;
+  value: unknown;
+  start: number;
+  end: number;
+};
+
+function removeTextRanges(text: string, ranges: Array<Pick<XmlParameterBlock, "start" | "end">>): string {
+  if (ranges.length === 0) {
+    return text;
+  }
+
+  let cursor = 0;
+  let stripped = "";
+  for (const range of [...ranges].sort((left, right) => left.start - right.start)) {
+    stripped += text.slice(cursor, range.start);
+    cursor = range.end;
+  }
+  stripped += text.slice(cursor);
+  return stripped;
+}
+
+function findMatchingXmlParameterClose(text: string, contentStartIndex: number): number {
+  let cursor = contentStartIndex;
+  let depth = 1;
+
+  while (cursor < text.length) {
+    const nextOpen = text.indexOf("<parameter=", cursor);
+    const nextClose = text.indexOf("</parameter>", cursor);
+    if (nextClose === -1) {
+      return -1;
+    }
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth += 1;
+      cursor = nextOpen + "<parameter=".length;
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) {
+      return nextClose;
+    }
+    cursor = nextClose + "</parameter>".length;
+  }
+
+  return -1;
+}
+
+function parseXmlStyleParameterBlocks(text: string): XmlParameterBlock[] {
+  const blocks: XmlParameterBlock[] = [];
+  const openPattern = /<parameter=([^>\n]+)>/gi;
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    openPattern.lastIndex = cursor;
+    const match = openPattern.exec(text);
+    if (!match || match.index < cursor) {
+      break;
+    }
+
+    const rawName = match[1]?.trim();
+    if (!rawName) {
+      cursor = match.index + match[0].length;
+      continue;
+    }
+
+    const contentStart = match.index + match[0].length;
+    const closeStart = findMatchingXmlParameterClose(text, contentStart);
+    if (closeStart === -1) {
+      cursor = contentStart;
+      continue;
+    }
+
+    const closeEnd = closeStart + "</parameter>".length;
+    const rawContent = text.slice(contentStart, closeStart);
+    const nestedBlocks = parseXmlStyleParameterBlocks(rawContent);
+    const outsideNestedText = removeTextRanges(rawContent, nestedBlocks).trim();
+    const value =
+      nestedBlocks.length > 0 && outsideNestedText.length === 0
+        ? Object.fromEntries(nestedBlocks.map((block) => [block.name, block.value]))
+        : rawContent.trim();
+
+    blocks.push({
+      name: rawName,
+      value,
+      start: match.index,
+      end: closeEnd,
+    });
+    cursor = closeEnd;
+  }
+
+  return blocks;
+}
+
+function extractXmlStyleFunctionCallCandidates(text: string): string[] {
+  const candidates = new Set<string>();
+  const functionPattern = /<function=([^>\n]+)>/gi;
+  const closingSentinels = ["</tool_call>", "</function>", "</execution>", "<function="] as const;
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  for (const match of trimmed.matchAll(functionPattern)) {
+    const rawName = match[1]?.trim();
+    if (!rawName) {
+      continue;
+    }
+
+    const bodyStart = (match.index ?? 0) + match[0].length;
+    let bodyEnd = trimmed.length;
+    for (const sentinel of closingSentinels) {
+      const nextIndex = trimmed.indexOf(sentinel, bodyStart);
+      if (nextIndex !== -1) {
+        bodyEnd = Math.min(bodyEnd, nextIndex);
+      }
+    }
+
+    const body = trimmed.slice(bodyStart, bodyEnd);
+    const parameterBlocks = parseXmlStyleParameterBlocks(body);
+    if (parameterBlocks.length === 0) {
+      continue;
+    }
+
+    candidates.add(
+      JSON.stringify({
+        name: rawName,
+        arguments: Object.fromEntries(parameterBlocks.map((block) => [block.name, block.value])),
+      }),
+    );
+  }
+
+  return [...candidates];
+}
+
 function extractToolPayloadCandidates(text: string): string[] {
   const candidates = new Set<string>(extractRawToolPayloadCandidates(text));
   const trimmed = text.trim();
   if (!trimmed) {
     return [...candidates];
+  }
+
+  for (const candidate of extractXmlStyleFunctionCallCandidates(trimmed)) {
+    candidates.add(candidate);
   }
 
   const pseudoToolWrapperPattern = /<([a-zA-Z][\w-]*)\b([^>]*)>([\s\S]*?)<\/\1>/gi;


### PR DESCRIPTION
Enhance handling of XML-like function payloads in Qwen models to prevent leakage of structured tool calls as plain text. Implement buffered repair for Qwen models and improve diagnostics for malformed tool-call arguments.