### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary environment variable exposure in Web Search Provider

### DIFF
--- a/sentinel.md
+++ b/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [CRITICAL] Fix arbitrary environment variable exposure in Web Search Provider
+**Vulnerability:** The `resolveNanoGptWebSearchApiKey` function in `web-search.ts` allowed the reading of arbitrary environment variables (e.g., `${AWS_SECRET_KEY}`) through the `apiKey` configuration.
+**Learning:** The legacy `${ENV_VAR}` pattern matching allowed any uppercase environment variable to be evaluated. This breaks isolation and allows config-driven exfiltration of sensitive environment values that OpenClaw is otherwise meant to protect.
+**Prevention:** Restrict the matched environment variable to exactly `NANOGPT_API_KEY`.

--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -300,6 +300,16 @@ describe("nanogpt web search provider", () => {
     expect(postTrustedWebToolsJsonMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not resolve unauthorized environment variables", () => {
+    process.env.AWS_SECRET = "super-secret-aws-key";
+
+    const apiKey = __testing.resolveNanoGptWebSearchApiKey({
+      apiKey: "${AWS_SECRET}",
+    });
+
+    expect(apiKey).toBeUndefined();
+  });
+
   it("resolves env secret refs from the provisioned NanoGPT web_search credential path", async () => {
     process.env.NANOGPT_API_KEY = "env-ref-key";
     postTrustedWebToolsJsonMock.mockImplementation(

--- a/web-search.ts
+++ b/web-search.ts
@@ -19,7 +19,7 @@ import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provi
 
 const NANOGPT_WEB_SEARCH_URL = "https://nano-gpt.com/api/web";
 const NANOGPT_WEB_SEARCH_CREDENTIAL_PATH = "plugins.entries.nanogpt.config.webSearch.apiKey";
-const NANOGPT_ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
+const NANOGPT_ENV_REF_PATTERN = /^\$\{(NANOGPT_API_KEY)\}$/;
 const NANOGPT_WEB_SEARCH_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -97,8 +97,12 @@ function resolveNanoGptWebSearchApiKey(searchConfig?: Record<string, unknown>): 
       ? NANOGPT_ENV_REF_PATTERN.exec(searchConfig.apiKey.trim())?.[1]
       : undefined;
 
+  const rawCredentialValue = searchConfig?.apiKey;
+  // If it looks like an environment variable but didn't match the safe pattern, don't pass it through
+  const isUnsafeEnvRef = typeof rawCredentialValue === "string" && /^\$\{([A-Z][A-Z0-9_]*)\}$/.test(rawCredentialValue.trim());
+
   return resolveWebSearchProviderCredential({
-    credentialValue: (inlineEnvRef ? readProviderEnvValue([inlineEnvRef]) : undefined) ?? searchConfig?.apiKey,
+    credentialValue: (inlineEnvRef ? readProviderEnvValue([inlineEnvRef]) : undefined) ?? (isUnsafeEnvRef ? undefined : rawCredentialValue),
     path: "tools.web.search.apiKey",
     envVars: ["NANOGPT_API_KEY"],
   });


### PR DESCRIPTION
This PR addresses a critical vulnerability in `web-search.ts` where arbitrary environment variables (e.g., `${AWS_SECRET}`) could be extracted and exposed due to an overly permissive regular expression mapping pattern, compromising repository security. The regex has been updated to explicitly accept only `${NANOGPT_API_KEY}`. Additional checks ensure unapproved patterns resolve to `undefined` without processing. An automated test guarantees this functionality remains secure.

---
*PR created automatically by Jules for task [9599400799178338783](https://jules.google.com/task/9599400799178338783) started by @deadronos*