### PR TITLE
Enhance repair functionality and add tests for Qwen models

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -5,11 +5,11 @@ import { describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 
 describe("nanogpt plugin entry", () => {
-  function getRegisteredProvider() {
+  function getRegisteredProvider(overrideConfig: Record<string, unknown> = {}) {
     const providers: unknown[] = [];
     plugin.register(
       {
-        pluginConfig: {},
+        pluginConfig: { enableRepair: false, ...overrideConfig },
         runtime: {
           logging: {
             shouldLogVerbose() {
@@ -282,8 +282,8 @@ describe("nanogpt plugin entry", () => {
     expect(responsesApiResult).toBeNull();
   });
 
-  it("only applies tool-call JSON repair to Kimi-style models", () => {
-    const provider = getRegisteredProvider();
+  it("only applies tool-call JSON repair to Kimi-style models when enableRepair is true", () => {
+    const provider = getRegisteredProvider({ enableRepair: true });
     expect(provider.wrapStreamFn).toEqual(expect.any(Function));
 
     const baseStreamFn = vi.fn();
@@ -306,7 +306,7 @@ describe("nanogpt plugin entry", () => {
   });
 
   it("buffers Kimi thinking models when tools are present and keeps GLM thinking models on the guard path", async () => {
-    const provider = getRegisteredProvider();
+    const provider = getRegisteredProvider({ enableRepair: true });
     expect(provider.wrapStreamFn).toEqual(expect.any(Function));
 
     const tools = [

--- a/index.ts
+++ b/index.ts
@@ -466,9 +466,39 @@ export default definePluginEntry({
       fetchUsageSnapshot: async (ctx) => await fetchNanoGptUsageSnapshot(ctx),
       wrapStreamFn: (ctx) => {
         if (ctx.streamFn) {
+          const config = getNanoGptConfig(api.pluginConfig);
+          const enableRepair = config.enableRepair;
+          if (enableRepair === undefined || enableRepair === false) {
+            return ctx.streamFn;
+          }
           const repairModelId =
             typeof ctx.model?.id === "string" && ctx.model.id.trim() ? ctx.model.id : ctx.modelId;
           const repairProfile = resolveNanoGptRepairProfile(repairModelId);
+
+          // Check per-family repair setting
+          let familyRepairEnabled = false;
+          if (typeof enableRepair === "boolean") {
+            familyRepairEnabled = enableRepair;
+          } else {
+            switch (repairProfile.family) {
+              case "kimi":
+                familyRepairEnabled = enableRepair.kimiRepair ?? false;
+                break;
+              case "glm":
+                familyRepairEnabled = enableRepair.glmRepair ?? false;
+                break;
+              case "qwen":
+                familyRepairEnabled = enableRepair.qwenRepair ?? false;
+                break;
+              default:
+                familyRepairEnabled = enableRepair.otherRepair ?? false;
+            }
+          }
+
+          if (!familyRepairEnabled) {
+            return ctx.streamFn;
+          }
+
           const reliabilityOptions = {
             debug: Boolean(api.runtime?.logging?.shouldLogVerbose?.()),
           };

--- a/models.ts
+++ b/models.ts
@@ -18,11 +18,19 @@ export type NanoGptCatalogSource =
   | "paid"
   | "personalized";
 
+export interface NanoGptRepairConfig {
+  kimiRepair?: boolean;
+  glmRepair?: boolean;
+  qwenRepair?: boolean;
+  otherRepair?: boolean;
+}
+
 export interface NanoGptPluginConfig {
   routingMode?: NanoGptRoutingMode;
   catalogSource?: NanoGptCatalogSource;
   requestApi?: "completions" | "responses" | "auto";
   provider?: string;
+  enableRepair?: boolean | NanoGptRepairConfig;
 }
 
 export interface NanoGptModelCapabilities {

--- a/repair.test.ts
+++ b/repair.test.ts
@@ -1332,6 +1332,61 @@ describe("wrapStreamWithToolCallRepair", () => {
     ]);
   });
 
+  it("salvages <tools> wrapper with JSON tool call payload for Qwen models", async () => {
+    const toolPayload =
+      '<tools>{"name": "read", "arguments": {"path": "src/index.ts"}}</tools>';
+
+    const mockStreamFn = vi.fn().mockResolvedValue((async function* () {
+      yield {
+        type: "done",
+        reason: "stop",
+        message: createAssistantMessage({
+          model: "qwen/Qwen3.6-35B-A3B",
+          content: [{ type: "text", text: toolPayload }],
+        }),
+      } satisfies AssistantMessageEvent;
+    })());
+
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const wrapped = wrapStreamWithToolCallRepair(mockStreamFn as any, logger);
+    const resultStream = await wrapped(
+      { id: "qwen/Qwen3.6-35B-A3B", api: "openai-completions" } as any,
+      {
+        messages: [],
+        tools: [
+          {
+            name: "read",
+            description: "Read a file",
+            parameters: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+              },
+              required: ["path"],
+            },
+          },
+        ],
+      } as any,
+      {} as any,
+    );
+
+    const doneMessage = await (resultStream as any).result();
+    expect(doneMessage.stopReason).toBe("toolUse");
+    expect(doneMessage.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_salvaged_1",
+        name: "read",
+        arguments: {
+          path: "src/index.ts",
+        },
+      },
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Salvaged structured tool payload"),
+    );
+  });
+
   it("rejects salvaged tool payloads whose tool names are not in the active inventory", async () => {
     const toolPayload = JSON.stringify({
       tool_calls: [

--- a/repair.ts
+++ b/repair.ts
@@ -67,7 +67,7 @@ const TOOL_CALL_CONTAINER_KEYS = ["tool_calls", "toolCalls", "tools", "calls", "
 const TOOL_ARGUMENT_KEYS = ["arguments", "args", "parameters", "input"] as const;
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const THINKING_PLACEHOLDER_RE = /^thinking(?:\.\.\.)?$/i;
-const PSEUDO_TOOL_WRAPPER_TAG_NAMES = new Set(["use_tool", "tool", "tool_call", "toolcall", "find", "glob", "read", "write", "exec", "bash", "run"]);
+const PSEUDO_TOOL_WRAPPER_TAG_NAMES = new Set(["use_tool", "tool", "tool_call", "toolcall", "tools", "find", "glob", "read", "write", "exec", "bash", "run"]);
 const PSEUDO_TOOL_NAME_ATTRIBUTE_PATTERN = /\bname\s*=\s*(?:"([^"]+)"|'([^']+)')/i;
 const TOOL_CALL_RESERVED_KEYS = new Set<string>([
   "id",
@@ -1402,7 +1402,16 @@ function extractToolPayloadCandidates(
 
       const parsedInner = parseJsonCandidate(innerCandidate);
       if (isRecord(parsedInner)) {
-        const mergedArgs = { ...allAttrs, ...parsedInner };
+        // If the body is a complete tool call payload with name/arguments,
+        // extract arguments directly and only merge non-reserved keys.
+        const innerArguments =
+          firstDefinedProperty(parsedInner, TOOL_ARGUMENT_KEYS) ?? parsedInner;
+        const mergedArgs = {
+          ...allAttrs,
+          ...Object.fromEntries(
+            Object.entries(innerArguments).filter(([k]) => !TOOL_CALL_RESERVED_KEYS.has(k)),
+          ),
+        };
         candidates.add(JSON.stringify({ name: toolName, arguments: mergedArgs }));
       } else {
         candidates.add(JSON.stringify({ name: toolName, arguments: parsedInner }));
@@ -1413,7 +1422,16 @@ function extractToolPayloadCandidates(
       if (isStructuredJsonCandidate(rawBody)) {
         const parsed = parseJsonCandidate(rawBody);
         if (isRecord(parsed)) {
-          const mergedArgs = { ...allAttrs, ...parsed };
+          // If the body is a complete tool call payload with name/arguments,
+          // extract arguments directly and only merge non-reserved keys.
+          const innerArguments =
+            firstDefinedProperty(parsed, TOOL_ARGUMENT_KEYS) ?? parsed;
+          const mergedArgs = {
+            ...allAttrs,
+            ...Object.fromEntries(
+              Object.entries(innerArguments).filter(([k]) => !TOOL_CALL_RESERVED_KEYS.has(k)),
+            ),
+          };
           candidates.add(JSON.stringify({ name: toolName, arguments: mergedArgs }));
         } else {
           candidates.add(JSON.stringify({ name: toolName, arguments: parsed }));

--- a/runtime.ts
+++ b/runtime.ts
@@ -361,6 +361,9 @@ export function getNanoGptConfig(config: unknown): NanoGptPluginConfig {
         ? candidate.requestApi
         : undefined,
     ...(provider ? { provider } : {}),
+    ...(candidate.enableRepair !== undefined && candidate.enableRepair !== null
+      ? { enableRepair: candidate.enableRepair }
+      : {}),
   };
 }
 


### PR DESCRIPTION
Introduce an `enableRepair` configuration to improve the repair functionality and add tests for salvaging the `<tools>` wrapper with JSON tool call payload specifically for Qwen models.