### PR TITLE
[codex] Implement NanoGPT structured error classification

### DIFF
--- a/docs/nanogpt-error-surface-mapping-2026-04-21.md
+++ b/docs/nanogpt-error-surface-mapping-2026-04-21.md
@@ -1,0 +1,423 @@
+# NanoGPT Error Surface Mapping for Issue #85
+
+Date: 2026-04-21
+
+Related issue: [#85](https://github.com/deadronos/nanogpt-provider-openclaw/issues/85)
+
+## Scope
+
+This note compares:
+
+- NanoGPT's documented error surface
+- the current `nanogpt-provider-openclaw` error handling
+- the OpenClaw SDK/runtime failure buckets we can target today
+
+The goal is to answer two questions:
+
+1. Are we classifying NanoGPT failures granularly enough?
+2. If not, how should NanoGPT statuses/types/codes map into OpenClaw failover paths?
+
+## Short answer
+
+Not yet.
+
+The plugin currently does **not** parse NanoGPT's documented `error.type`, `error.code`, `param`, `Retry-After`, or SSE mid-stream error frames on the inference path. It mostly relies on OpenClaw's generic failover classifier plus one NanoGPT-specific warning in [`index.ts`](../index.ts) that treats any `402`-looking error as a billing event for logging purposes.
+
+That means:
+
+- classification is only as good as the raw error text OpenClaw happens to receive
+- plugin logging is **too generic** for issue #85
+- a NanoGPT error that is really a transient quota/rate-limit shape can still be logged as "billing"
+- we are leaving documented NanoGPT machine-readable codes unused
+
+## Sources consulted
+
+NanoGPT docs:
+
+- [Error Handling](https://docs.nano-gpt.com/api-reference/miscellaneous/error-handling)
+- [Rate Limits](https://docs.nano-gpt.com/api-reference/miscellaneous/rate-limits)
+- [Provider Selection](https://docs.nano-gpt.com/api-reference/miscellaneous/provider-selection)
+- [Chat Completion](https://docs.nano-gpt.com/api-reference/endpoint/chat-completion)
+
+Plugin repo:
+
+- [`index.ts`](../index.ts)
+- [`runtime.ts`](../runtime.ts)
+- [`provider-catalog.ts`](../provider-catalog.ts)
+- [`docs/openclaw-provider-model-request-lifecycle-hooks-2026-04-16.md`](./openclaw-provider-model-request-lifecycle-hooks-2026-04-16.md)
+
+OpenClaw source:
+
+- `~/Github/openclaw/src/plugins/types.ts`
+- `~/Github/openclaw/src/plugins/provider-runtime.ts`
+- `~/Github/openclaw/src/agents/pi-embedded-helpers/errors.ts`
+- `~/Github/openclaw/src/agents/pi-embedded-helpers/provider-error-patterns.ts`
+- `~/Github/openclaw/src/agents/pi-embedded-helpers/types.ts`
+- `~/Github/openclaw/src/commands/models/list.probe.ts`
+- `~/Github/openclaw/src/agents/failover-policy.ts`
+- `~/Github/openclaw/src/agents/pi-embedded-runner/run/failover-policy.ts`
+
+Installed OpenClaw spot-check:
+
+- `node_modules/openclaw/dist/plugin-sdk/src/plugins/types.d.ts`
+- `node_modules/openclaw/dist/plugin-sdk/src/plugins/provider-runtime.d.ts`
+
+## NanoGPT documented error surface
+
+### Error envelopes
+
+NanoGPT documents three common shapes:
+
+1. OpenAI-compatible:
+
+```json
+{
+  "error": {
+    "message": "Human-readable error message",
+    "type": "invalid_request_error",
+    "code": "missing_required_parameter",
+    "param": "model"
+  }
+}
+```
+
+2. Anthropic-compatible (`/api/v1/messages`):
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "max_tokens is required",
+    "param": "max_tokens"
+  }
+}
+```
+
+3. Legacy/simple:
+
+```json
+{ "error": "Insufficient balance", "status": 402 }
+```
+
+### Documented status meanings
+
+| HTTP | NanoGPT meaning | Retry guidance from docs |
+| --- | --- | --- |
+| `400` | Invalid request / validation failed | No |
+| `401` | Missing or invalid API key | No |
+| `402` | Insufficient balance | No |
+| `403` | Authenticated but not permitted | No |
+| `404` | Resource not found | No |
+| `408` / `504` | Timeout | Yes |
+| `409` | Conflict | No |
+| `413` | Payload too large | No |
+| `429` | Rate limited | Yes; use `Retry-After` if present |
+| `500` | Server error | Yes |
+| `503` | Temporarily unavailable | Yes |
+
+### Documented error types
+
+| Type | Typical HTTP |
+| --- | --- |
+| `invalid_request_error` | `400` |
+| `authentication_error` | `401` |
+| `permission_denied_error` / `permission_error` | `403` |
+| `not_found_error` | `404` |
+| `rate_limit_error` | `429` |
+| `server_error` / `service_unavailable` / `api_error` | `500` / `503` |
+
+### Documented error codes
+
+Request validation:
+
+- `missing_required_parameter`
+- `invalid_parameter_value`
+- `invalid_json`
+- `invalid_json_schema`
+- `tool_choice_unsupported`
+- `image_input_not_supported`
+
+Content and context:
+
+- `content_policy_violation`
+- `context_length_exceeded`
+- `empty_response`
+
+Model and routing:
+
+- `model_not_found`
+- `model_not_allowed`
+- `model_not_available`
+- `all_fallbacks_failed`
+- `no_fallback_available`
+- `fallback_blocked_for_cache_consistency`
+
+Balance and payment:
+
+- `memory_balance_required`
+- `webSearch_balance_required`
+- `both_balance_required`
+
+Rate limiting:
+
+- `rate_limit_exceeded`
+- `daily_rpd_limit_exceeded`
+- `daily_usd_limit_exceeded`
+
+Other documented behaviors worth using:
+
+- `429` daily-key limits should include `Retry-After`
+- SSE can fail mid-stream with an `error` object containing `status`, `message`, and `code`
+- `402` may also arrive as an X-402 payment challenge with `error.code: "insufficient_quota"`
+
+## OpenClaw surfaces we can target today
+
+### Provider hooks available to this plugin
+
+OpenClaw exposes these relevant provider hooks:
+
+- `classifyFailoverReason(ctx)`
+- `matchesContextOverflowError(ctx)`
+- `resolveUsageAuth(ctx)`
+- `fetchUsageSnapshot(ctx)`
+
+The hook surface matches in both:
+
+- local source at `~/Github/openclaw/src/plugins/types.ts`
+- installed package types at `node_modules/openclaw/dist/plugin-sdk/src/plugins/types.d.ts`
+
+### OpenClaw failover reasons
+
+OpenClaw's failover reason union is:
+
+- `auth`
+- `auth_permanent`
+- `format`
+- `rate_limit`
+- `overloaded`
+- `billing`
+- `timeout`
+- `model_not_found`
+- `session_expired`
+- `unknown`
+
+### Probe status collapse
+
+OpenClaw's model-auth probe collapses those reasons to:
+
+| Failover reason | Probe status |
+| --- | --- |
+| `auth`, `auth_permanent` | `auth` |
+| `rate_limit`, `overloaded` | `rate_limit` |
+| `billing` | `billing` |
+| `timeout` | `timeout` |
+| `model_not_found`, `format` | `format` |
+| `unknown` / unset | `unknown` |
+
+### Why the exact mapping matters
+
+The reason is not just cosmetic.
+
+OpenClaw treats the buckets differently:
+
+- `billing` can put a provider on billing cooldown and skip same-provider candidates
+- `rate_limit`, `overloaded`, and `timeout` are treated as transient
+- `model_not_found` and `format` avoid the same transient cooldown path
+- `auth` and `auth_permanent` can push auth/profile rotation behavior
+
+So misclassifying a transient NanoGPT quota/routing issue as `billing` is expensive.
+
+## Current plugin behavior
+
+### What the plugin already does well
+
+- It strips `X-Provider` during subscription routing in [`runtime.ts`](../runtime.ts), which matches NanoGPT's docs that subscription requests ignore provider preferences unless billing is explicitly forced to paygo.
+- It has a separate NanoGPT usage snapshot integration in [`runtime.ts`](../runtime.ts).
+
+### Where the plugin is currently too generic
+
+Inference-path error handling is effectively:
+
+1. let OpenClaw's generic classifier inspect the raw error message
+2. add one NanoGPT-specific warning in [`index.ts`](../index.ts) when the message contains `402` or `Insufficient balance`
+3. do **not** parse NanoGPT `error.type` / `error.code`
+
+Current code:
+
+- [`index.ts`](../index.ts) logs a billing warning when `ctx.errorMessage.includes("402") || ctx.errorMessage.includes("Insufficient balance")`
+- it then returns `undefined`, so the real failover reason still comes from OpenClaw generic matching
+
+That means the plugin warning can say "billing" even when the core classifier would prefer something else.
+
+## Key finding for issue #85
+
+The current NanoGPT-specific logging is **not granular enough**.
+
+For issue #85, there are two distinct possibilities:
+
+1. NanoGPT is returning a genuine balance/payment failure.
+2. NanoGPT is returning a transient quota/routing/provider state that is only surfacing as a generic `402`-ish message.
+
+Today the plugin logs both as billing-like.
+
+Also, because the plugin does not parse NanoGPT's machine-readable `error.code`, it cannot distinguish:
+
+- true insufficient balance
+- daily/key limits
+- content policy / empty response
+- model/routing failures
+- X-402 payment challenge variants
+
+from the NanoGPT surface itself.
+
+## Recommended mapping
+
+### Status/type/code to OpenClaw reason
+
+| NanoGPT signal | Recommended OpenClaw mapping | Notes |
+| --- | --- | --- |
+| `401` / `authentication_error` | `auth` | Generic OpenClaw already does this well. |
+| `403` + generic permission/auth failure | `auth` | Good default for actual credential/scope failures. |
+| `403` + `model_not_allowed` | `model_not_found` | Better than `auth` for "this model is not usable, try another model". |
+| `404` / `not_found_error` / `model_not_found` | `model_not_found` | Generic OpenClaw already supports this. |
+| `402` + `Insufficient balance` / `insufficient_quota` / `*_balance_required` | `billing` | Real paid-balance failure. |
+| `429` / `rate_limit_error` / `rate_limit_exceeded` | `rate_limit` | Should log `Retry-After` when visible. |
+| `429` / `daily_rpd_limit_exceeded` / `daily_usd_limit_exceeded` | `rate_limit` | Daily limits are documented as `429`, not `402`. |
+| `500` + transient `api_error` / `server_error` | `timeout` | Matches OpenClaw's current generic treatment. |
+| `503` / `service_unavailable` | `overloaded` | Better fit than billing; may already classify generically from message text. |
+| `408` / `504` | `timeout` | Retryable. |
+| `400` / `422` validation codes | `format` | Request needs fixing, not provider cooldown. |
+| `content_policy_violation` | `format` | Non-retryable request/content failure; should never look like billing. |
+| `context_length_exceeded` | `matchesContextOverflowError = true` | Prefer the dedicated context-overflow hook over a failover reason. |
+| `empty_response` | `format` | Best current fit in SDK; importantly, not `billing`. |
+| `model_not_available` | `model_not_found` | Closest existing bucket; suggests switching models. |
+| `all_fallbacks_failed` | `unknown` | Routing umbrella code; log it explicitly rather than guessing. |
+| `no_fallback_available` | `format` | Request/config-driven routing constraint, not provider billing. |
+| `fallback_blocked_for_cache_consistency` | `format` | Also request/config-driven, not billing. |
+
+### Extra note on `402`
+
+NanoGPT's docs describe real balance failures as `402`.
+
+They separately document daily key limits as `429`.
+
+So if we see issue #85 producing a `402` that later self-heals after a few hours, that is either:
+
+- an undocumented NanoGPT transient quota/routing surface
+- an upstream provider response being proxied through NanoGPT with reduced detail
+- or a real NanoGPT billing path that is being triggered incorrectly upstream
+
+That last-mile ambiguity is exactly why the plugin should parse as much structured NanoGPT error data as it can before falling back to text heuristics.
+
+## What OpenClaw generic handling already gives us
+
+OpenClaw is already more nuanced than the plugin-specific warning suggests:
+
+- it can classify some `402` text as `rate_limit` instead of `billing`
+- it distinguishes `auth`, `auth_permanent`, `model_not_found`, `timeout`, `overloaded`, and `format`
+- it already has special handling for context overflow and some provider-specific payloads
+
+So the main gap is **not** that OpenClaw lacks buckets.
+
+The main gaps are:
+
+1. the NanoGPT plugin does not feed those buckets structured NanoGPT information
+2. the plugin's own warning text is too broad and can be misleading
+
+## Proposed implementation plan
+
+### 1. Add a NanoGPT-specific error parser
+
+Create a small helper module, for example `nanogpt-errors.ts`, that can parse:
+
+- OpenAI-compatible NanoGPT errors
+- Anthropic-compatible NanoGPT errors
+- legacy `{ error: string, status: number }` bodies
+- SSE mid-stream error frames when they are surfaced as raw strings
+
+It should extract:
+
+- `status`
+- `type`
+- `code`
+- `message`
+- `param`
+- whether the shape looks like X-402
+- any visible `Retry-After`
+
+### 2. Use provider-owned hooks instead of raw-string-only logging
+
+In `registerProvider(...)`:
+
+- replace the current broad `402` warning in [`index.ts`](../index.ts)
+- implement NanoGPT-aware `classifyFailoverReason`
+- implement `matchesContextOverflowError` for `context_length_exceeded`
+
+### 3. Make logging reason-specific
+
+Log by resolved reason, not by substring:
+
+- `billing`: "NanoGPT reported insufficient paid balance / x402 requirement"
+- `rate_limit`: "NanoGPT reported rate limiting or daily-key exhaustion"
+- `model_not_found`: "NanoGPT rejected model/routing selection"
+- `format`: "NanoGPT rejected request payload/content"
+- `overloaded` / `timeout`: "NanoGPT transient upstream/service failure"
+
+If we can see them, also log:
+
+- NanoGPT `error.code`
+- NanoGPT `error.type`
+- `Retry-After`
+- model id
+- whether routing was `subscription` or `paygo`
+
+### 4. Preserve the good subscription/paygo guardrail
+
+Keep the current behavior that avoids sending `X-Provider` on subscription requests.
+
+This matches NanoGPT's docs and remains the right default:
+
+- subscription requests ignore provider overrides unless billing is explicitly forced to paygo
+- sending provider overrides accidentally can produce paid-route behavior and misleading balance failures
+
+### 5. Add tests for the full mapping
+
+Suggested cases:
+
+- `402` legacy insufficient balance -> `billing`
+- `402` X-402 insufficient quota -> `billing`
+- `429` `rate_limit_exceeded` -> `rate_limit`
+- `429` `daily_rpd_limit_exceeded` -> `rate_limit`
+- `400` `content_policy_violation` -> `format`
+- `400` `context_length_exceeded` -> context-overflow hook
+- `403` `model_not_allowed` -> `model_not_found`
+- `404` `model_not_found` -> `model_not_found`
+- `503` `service_unavailable` -> `overloaded`
+- SSE error frame with `code: "service_unavailable"` -> `overloaded`
+
+## Practical conclusion for issue #85
+
+The current plugin is not "wrong" in the sense that it bypasses OpenClaw's failure taxonomy; OpenClaw core still does most of the real classification work.
+
+But it is **too generic** in two ways that matter for this bug:
+
+1. it does not parse NanoGPT's documented machine-readable error surface
+2. it emits a NanoGPT-specific billing warning for any `402`-looking failure
+
+So the right next step is not a broad retry layer first.
+
+The right next step is:
+
+1. parse NanoGPT errors structurally
+2. map them into OpenClaw's existing failover buckets deliberately
+3. make logging reflect the resolved bucket instead of a blanket "billing" story
+
+That should let us separate:
+
+- true NanoGPT paygo balance problems
+- daily-key or quota exhaustion
+- model/routing failures
+- transient upstream/provider issues
+
+which is exactly what issue #85 needs.

--- a/index.test.ts
+++ b/index.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 
 describe("nanogpt plugin entry", () => {
-  function getRegisteredProvider(overrideConfig: Record<string, unknown> = {}) {
+  function getRegisteredProviderHarness(overrideConfig: Record<string, unknown> = {}) {
     const providers: unknown[] = [];
+    const warn = vi.fn();
+    const info = vi.fn();
     plugin.register(
       {
         pluginConfig: { enableRepair: false, ...overrideConfig },
@@ -18,8 +20,8 @@ describe("nanogpt plugin entry", () => {
           },
         },
         logger: {
-          warn: vi.fn(),
-          info: vi.fn(),
+          warn,
+          info,
         },
         registerProvider(provider: unknown) {
           providers.push(provider);
@@ -28,87 +30,106 @@ describe("nanogpt plugin entry", () => {
         registerImageGenerationProvider() {},
       } as never,
     );
-    return providers[0] as {
-      applyNativeStreamingUsageCompat?: (ctx: {
-        providerConfig: {
-          api: string;
-          baseUrl?: string;
-          models?: Array<Record<string, unknown>>;
-        };
-      }) => unknown;
-      wrapStreamFn?: (ctx: {
-        streamFn?: (...args: unknown[]) => unknown;
-        modelId: string;
-        model?: {
-          id?: string;
-        };
-      }) => unknown;
-      normalizeToolSchemas?: (ctx: {
-        provider: string;
-        modelId?: string;
-        model?: {
-          id: string;
-          provider?: string;
-          api?: string;
-          baseUrl?: string;
-        };
-        tools: Array<Record<string, unknown>>;
-      }) => unknown;
-      inspectToolSchemas?: (ctx: {
-        provider: string;
-        modelId?: string;
-        model?: {
-          id: string;
-          provider?: string;
-          api?: string;
-          baseUrl?: string;
-        };
-        tools: Array<Record<string, unknown>>;
-      }) => unknown;
-      augmentModelCatalog?: (ctx: {
-        agentDir?: string;
-        config?: Record<string, unknown>;
-        env?: Record<string, string | undefined>;
-        entries: Array<Record<string, unknown>>;
-      }) => unknown;
-      normalizeResolvedModel?: (ctx: {
-        agentDir?: string;
-        provider: string;
-        modelId: string;
-        model: {
-          id: string;
-          name: string;
-          provider: string;
-          api: string;
-          baseUrl?: string;
-          reasoning: boolean;
-          input: Array<"text" | "image" | "document">;
-          cost: {
-            input: number;
-            output: number;
-            cacheRead: number;
-            cacheWrite: number;
+
+    return {
+      warn,
+      info,
+      provider: providers[0] as {
+        applyNativeStreamingUsageCompat?: (ctx: {
+          providerConfig: {
+            api: string;
+            baseUrl?: string;
+            models?: Array<Record<string, unknown>>;
           };
-          contextWindow: number;
-          maxTokens: number;
-          compat?: Record<string, unknown>;
-        };
-      }) => unknown;
-      resolveDynamicModel?: (ctx: {
-        agentDir?: string;
-        env?: Record<string, string | undefined>;
-        provider: string;
-        modelId: string;
-        modelRegistry: unknown;
-        providerConfig?: {
-          api?: string;
-          baseUrl?: string;
-          models?: Array<Record<string, unknown>>;
-        };
-      }) => unknown;
-      resolveUsageAuth?: unknown;
-      fetchUsageSnapshot?: unknown;
+        }) => unknown;
+        wrapStreamFn?: (ctx: {
+          streamFn?: (...args: unknown[]) => unknown;
+          modelId: string;
+          model?: {
+            id?: string;
+          };
+        }) => unknown;
+        normalizeToolSchemas?: (ctx: {
+          provider: string;
+          modelId?: string;
+          model?: {
+            id: string;
+            provider?: string;
+            api?: string;
+            baseUrl?: string;
+          };
+          tools: Array<Record<string, unknown>>;
+        }) => unknown;
+        inspectToolSchemas?: (ctx: {
+          provider: string;
+          modelId?: string;
+          model?: {
+            id: string;
+            provider?: string;
+            api?: string;
+            baseUrl?: string;
+          };
+          tools: Array<Record<string, unknown>>;
+        }) => unknown;
+        augmentModelCatalog?: (ctx: {
+          agentDir?: string;
+          config?: Record<string, unknown>;
+          env?: Record<string, string | undefined>;
+          entries: Array<Record<string, unknown>>;
+        }) => unknown;
+        normalizeResolvedModel?: (ctx: {
+          agentDir?: string;
+          provider: string;
+          modelId: string;
+          model: {
+            id: string;
+            name: string;
+            provider: string;
+            api: string;
+            baseUrl?: string;
+            reasoning: boolean;
+            input: Array<"text" | "image" | "document">;
+            cost: {
+              input: number;
+              output: number;
+              cacheRead: number;
+              cacheWrite: number;
+            };
+            contextWindow: number;
+            maxTokens: number;
+            compat?: Record<string, unknown>;
+          };
+        }) => unknown;
+        resolveDynamicModel?: (ctx: {
+          agentDir?: string;
+          env?: Record<string, string | undefined>;
+          provider: string;
+          modelId: string;
+          modelRegistry: unknown;
+          providerConfig?: {
+            api?: string;
+            baseUrl?: string;
+            models?: Array<Record<string, unknown>>;
+          };
+        }) => unknown;
+        resolveUsageAuth?: unknown;
+        fetchUsageSnapshot?: unknown;
+        matchesContextOverflowError?: (ctx: {
+          provider?: string;
+          modelId?: string;
+          errorMessage: string;
+        }) => boolean | undefined;
+        classifyFailoverReason?: (ctx: {
+          provider?: string;
+          modelId?: string;
+          errorMessage: string;
+        }) => string | null | undefined;
+      },
     };
+  }
+
+  function getRegisteredProvider(overrideConfig: Record<string, unknown> = {}) {
+    return getRegisteredProviderHarness(overrideConfig).provider;
   }
 
   function getRegisteredProviderWithAuth() {
@@ -196,6 +217,125 @@ describe("nanogpt plugin entry", () => {
     );
     expect((providers[0] as { applyNativeStreamingUsageCompat?: unknown }).applyNativeStreamingUsageCompat).toEqual(
       expect.any(Function),
+    );
+  });
+
+  it("classifies structured NanoGPT rate limits and logs the mapped reason once", () => {
+    const { provider, warn } = getRegisteredProviderHarness();
+    expect(provider.classifyFailoverReason).toEqual(expect.any(Function));
+
+    const errorMessage = JSON.stringify({
+      error: {
+        message: "Daily request limit exceeded",
+        type: "rate_limit_error",
+        code: "daily_rpd_limit_exceeded",
+      },
+      status: 429,
+    });
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "nanogpt",
+        modelId: "moonshotai/kimi-k2.5:thinking",
+        errorMessage,
+      }),
+    ).toBe("rate_limit");
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "nanogpt",
+        modelId: "moonshotai/kimi-k2.5:thinking",
+        errorMessage,
+      }),
+    ).toBe("rate_limit");
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("classified as rate_limit"),
+    );
+  });
+
+  it("warns and falls through when NanoGPT returns a recognized but unmapped error code", () => {
+    const { provider, warn } = getRegisteredProviderHarness();
+    expect(provider.classifyFailoverReason).toEqual(expect.any(Function));
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "nanogpt",
+        modelId: "moonshotai/kimi-k2.5:thinking",
+        errorMessage: JSON.stringify({
+          error: {
+            message: "Every configured fallback failed",
+            type: "server_error",
+            code: "all_fallbacks_failed",
+          },
+          status: 409,
+        }),
+      }),
+    ).toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("recognized but not mapped"),
+    );
+  });
+
+  it("warns and falls through when NanoGPT returns an unknown structured error envelope", () => {
+    const { provider, warn } = getRegisteredProviderHarness();
+    expect(provider.classifyFailoverReason).toEqual(expect.any(Function));
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "nanogpt",
+        modelId: "moonshotai/kimi-k2.5:thinking",
+        errorMessage: JSON.stringify({
+          error: {
+            detail: "surprising payload",
+          },
+          status: 418,
+        }),
+      }),
+    ).toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Unknown NanoGPT API error envelope"),
+    );
+  });
+
+  it("routes NanoGPT context length errors through the context overflow hook", () => {
+    const { provider, warn } = getRegisteredProviderHarness();
+    expect(provider.matchesContextOverflowError).toEqual(expect.any(Function));
+    expect(provider.classifyFailoverReason).toEqual(expect.any(Function));
+
+    const errorMessage = JSON.stringify({
+      error: {
+        message: "Context length exceeded",
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+      },
+      status: 400,
+    });
+
+    expect(
+      provider.matchesContextOverflowError?.({
+        provider: "nanogpt",
+        modelId: "moonshotai/kimi-k2.5:thinking",
+        errorMessage,
+      }),
+    ).toBe(true);
+
+    expect(
+      provider.classifyFailoverReason?.({
+        provider: "nanogpt",
+        modelId: "moonshotai/kimi-k2.5:thinking",
+        errorMessage,
+      }),
+    ).toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("context overflow handling"),
     );
   });
 

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,10 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { buildNanoGptImageGenerationProvider } from "./image-generation-provider.js";
+import {
+  formatNanoGptErrorSurfaceDetails,
+  inspectNanoGptErrorSurface,
+} from "./nanogpt-errors.js";
 import { applyNanoGptProviderAuthConfig, applyNanoGptProviderConfig } from "./onboard.js";
 import { NANOGPT_DEFAULT_MODEL_REF, NANOGPT_PROVIDER_ID } from "./models.js";
 import { buildNanoGptProvider, readNanoGptModelsJsonSnapshot } from "./provider-catalog.js";
@@ -424,12 +428,75 @@ function inspectNanoGptToolSchemas(
   return diagnostics.length > 0 ? diagnostics : null;
 }
 
+function summarizeNanoGptErrorMessage(message: string | undefined): string {
+  const normalized = message?.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "(no message)";
+  }
+  return normalized.length > 200 ? `${normalized.slice(0, 197)}...` : normalized;
+}
+
 export default definePluginEntry({
   id: NANOGPT_PROVIDER_ID,
   name: "NanoGPT Provider",
   description: "NanoGPT provider plugin for OpenClaw",
   register(api) {
     const pluginConfig = api.pluginConfig;
+    const resolvedNanoGptConfig = getNanoGptConfig(pluginConfig);
+    const warnedNanoGptErrorSignatures = new Set<string>();
+
+    function warnNanoGptErrorSurface(params: {
+      modelId?: string;
+      kind: "mapped" | "context_overflow" | "recognized_unmapped" | "unknown_structured";
+      details: string;
+      message?: string;
+      reason?: string;
+    }): void {
+      const modelId = params.modelId?.trim() || "(unknown model)";
+      const routingMode = resolvedNanoGptConfig.routingMode ?? "auto";
+      const providerOverride = resolvedNanoGptConfig.provider?.trim() || "auto";
+      const signature = [
+        params.kind,
+        params.reason ?? "",
+        modelId,
+        routingMode,
+        providerOverride,
+        params.details,
+      ].join("|");
+
+      if (warnedNanoGptErrorSignatures.has(signature)) {
+        return;
+      }
+      warnedNanoGptErrorSignatures.add(signature);
+
+      const context = `[${params.details}, routingMode=${routingMode}, providerOverride=${providerOverride}]`;
+      const summary = summarizeNanoGptErrorMessage(params.message);
+
+      if (params.kind === "mapped") {
+        api.logger.warn(
+          `NanoGPT API error classified as ${params.reason} for model ${modelId} ${context}: ${summary}`,
+        );
+        return;
+      }
+
+      if (params.kind === "context_overflow") {
+        api.logger.warn(
+          `NanoGPT API error matched OpenClaw context overflow handling for model ${modelId} ${context}: ${summary}`,
+        );
+        return;
+      }
+
+      if (params.kind === "recognized_unmapped") {
+        api.logger.warn(
+          `NanoGPT API error recognized but not mapped to an OpenClaw failover reason for model ${modelId} ${context}: ${summary}. Falling back to OpenClaw generic classification.`,
+        );
+        return;
+      }
+
+      api.logger.warn(
+        `Unknown NanoGPT API error envelope for model ${modelId} ${context}: ${summary}. Falling back to OpenClaw generic classification.`,
+      );
+    }
 
     api.registerProvider({
       id: NANOGPT_PROVIDER_ID,
@@ -477,15 +544,43 @@ export default definePluginEntry({
         }
         return undefined;
       },
-      classifyFailoverReason: (ctx) => {
-        if (
-          (ctx.errorMessage.includes("402") || ctx.errorMessage.includes("Insufficient balance")) &&
-          !getNanoGptConfig(api.pluginConfig).provider
-        ) {
-          api.logger.warn(
-            `NanoGPT upstream billing error on model ${ctx.modelId}. This typically means an hourly subscription limit was reached, or a provider failover misrouted to your empty PayGo wallet.`
-          );
+      matchesContextOverflowError: (ctx) => {
+        const inspection = inspectNanoGptErrorSurface(ctx.errorMessage);
+        if (inspection?.kind !== "context_overflow") {
+          return undefined;
         }
+
+        warnNanoGptErrorSurface({
+          modelId: ctx.modelId,
+          kind: inspection.kind,
+          details: formatNanoGptErrorSurfaceDetails(inspection.error),
+          message: inspection.error.message ?? ctx.errorMessage,
+        });
+        return true;
+      },
+      classifyFailoverReason: (ctx) => {
+        const inspection = inspectNanoGptErrorSurface(ctx.errorMessage);
+        if (!inspection) {
+          return undefined;
+        }
+
+        if (inspection.kind === "mapped") {
+          warnNanoGptErrorSurface({
+            modelId: ctx.modelId,
+            kind: inspection.kind,
+            reason: inspection.reason,
+            details: formatNanoGptErrorSurfaceDetails(inspection.error),
+            message: inspection.error.message ?? ctx.errorMessage,
+          });
+          return inspection.reason;
+        }
+
+        warnNanoGptErrorSurface({
+          modelId: ctx.modelId,
+          kind: inspection.kind,
+          details: formatNanoGptErrorSurfaceDetails(inspection.error),
+          message: inspection.error.message ?? ctx.errorMessage,
+        });
         return undefined;
       },
     });

--- a/nanogpt-errors.test.ts
+++ b/nanogpt-errors.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatNanoGptErrorSurfaceDetails,
+  inspectNanoGptErrorSurface,
+} from "./nanogpt-errors.js";
+
+describe("inspectNanoGptErrorSurface", () => {
+  it("maps structured NanoGPT rate limit errors to OpenClaw rate_limit", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: {
+            message: "Daily request limit exceeded",
+            type: "rate_limit_error",
+            code: "daily_rpd_limit_exceeded",
+          },
+          status: 429,
+        }),
+      ),
+    ).toEqual({
+      kind: "mapped",
+      reason: "rate_limit",
+      error: expect.objectContaining({
+        envelope: "openai",
+        status: 429,
+        type: "rate_limit_error",
+        code: "daily_rpd_limit_exceeded",
+      }),
+    });
+  });
+
+  it("maps legacy NanoGPT balance errors to OpenClaw billing", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: "Insufficient balance",
+          status: 402,
+        }),
+      ),
+    ).toEqual({
+      kind: "mapped",
+      reason: "billing",
+      error: expect.objectContaining({
+        envelope: "legacy",
+        status: 402,
+        message: "Insufficient balance",
+      }),
+    });
+  });
+
+  it("maps structured NanoGPT content policy errors to OpenClaw format", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: {
+            message: "Blocked by content policy",
+            type: "invalid_request_error",
+            code: "content_policy_violation",
+          },
+          status: 400,
+        }),
+      ),
+    ).toEqual({
+      kind: "mapped",
+      reason: "format",
+      error: expect.objectContaining({
+        envelope: "openai",
+        status: 400,
+        code: "content_policy_violation",
+      }),
+    });
+  });
+
+  it("maps structured NanoGPT context errors to context overflow handling", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: {
+            message: "Context length exceeded",
+            type: "invalid_request_error",
+            code: "context_length_exceeded",
+            param: "messages",
+          },
+          status: 400,
+        }),
+      ),
+    ).toEqual({
+      kind: "context_overflow",
+      error: expect.objectContaining({
+        envelope: "openai",
+        status: 400,
+        code: "context_length_exceeded",
+        param: "messages",
+      }),
+    });
+  });
+
+  it("maps model access rejections to OpenClaw model_not_found", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: {
+            message: "Model is not allowed for this account",
+            type: "permission_error",
+            code: "model_not_allowed",
+          },
+          status: 403,
+        }),
+      ),
+    ).toEqual({
+      kind: "mapped",
+      reason: "model_not_found",
+      error: expect.objectContaining({
+        envelope: "openai",
+        status: 403,
+        type: "permission_error",
+        code: "model_not_allowed",
+      }),
+    });
+  });
+
+  it("falls through recognized but unmapped NanoGPT error codes", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: {
+            message: "Every configured fallback failed",
+            type: "server_error",
+            code: "all_fallbacks_failed",
+          },
+          status: 409,
+        }),
+      ),
+    ).toEqual({
+      kind: "recognized_unmapped",
+      error: expect.objectContaining({
+        envelope: "openai",
+        status: 409,
+        type: "server_error",
+        code: "all_fallbacks_failed",
+      }),
+    });
+  });
+
+  it("flags unknown structured NanoGPT-like responses for warning fallthrough", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        JSON.stringify({
+          error: {
+            detail: "surprising payload",
+          },
+          status: 418,
+        }),
+      ),
+    ).toEqual({
+      kind: "unknown_structured",
+      error: expect.objectContaining({
+        envelope: "unknown_structured",
+        status: 418,
+        jsonKeys: ["error", "status"],
+      }),
+    });
+  });
+});
+
+describe("formatNanoGptErrorSurfaceDetails", () => {
+  it("renders structured detail fields compactly", () => {
+    expect(
+      formatNanoGptErrorSurfaceDetails({
+        envelope: "openai",
+        status: 429,
+        type: "rate_limit_error",
+        code: "daily_rpd_limit_exceeded",
+        param: "model",
+        retryAfterSeconds: 3600,
+      }),
+    ).toBe(
+      "envelope=openai, status=429, type=rate_limit_error, code=daily_rpd_limit_exceeded, param=model, retryAfter=3600s",
+    );
+  });
+});

--- a/nanogpt-errors.ts
+++ b/nanogpt-errors.ts
@@ -1,0 +1,458 @@
+type NanoGptFailoverReason =
+  | "auth"
+  | "auth_permanent"
+  | "format"
+  | "rate_limit"
+  | "overloaded"
+  | "billing"
+  | "timeout"
+  | "model_not_found"
+  | "session_expired"
+  | "unknown";
+
+type NanoGptRecognizedEnvelope = "openai" | "anthropic" | "legacy" | "sse";
+
+export type NanoGptRecognizedError = {
+  envelope: NanoGptRecognizedEnvelope;
+  status?: number;
+  type?: string;
+  code?: string;
+  message?: string;
+  param?: string;
+  retryAfterSeconds?: number;
+  raw: string;
+};
+
+export type NanoGptUnknownStructuredError = {
+  envelope: "unknown_structured";
+  status?: number;
+  type?: string;
+  code?: string;
+  message?: string;
+  jsonKeys: string[];
+  raw: string;
+};
+
+export type NanoGptErrorSurfaceInspection =
+  | {
+      kind: "mapped";
+      reason: NanoGptFailoverReason;
+      error: NanoGptRecognizedError;
+    }
+  | {
+      kind: "context_overflow";
+      error: NanoGptRecognizedError;
+    }
+  | {
+      kind: "recognized_unmapped";
+      error: NanoGptRecognizedError;
+    }
+  | {
+      kind: "unknown_structured";
+      error: NanoGptUnknownStructuredError;
+    };
+
+const FORMAT_ERROR_CODES = new Set([
+  "missing_required_parameter",
+  "invalid_parameter_value",
+  "invalid_json",
+  "invalid_json_schema",
+  "tool_choice_unsupported",
+  "image_input_not_supported",
+  "content_policy_violation",
+  "empty_response",
+  "no_fallback_available",
+  "fallback_blocked_for_cache_consistency",
+]);
+
+const BILLING_ERROR_CODES = new Set([
+  "insufficient_quota",
+  "memory_balance_required",
+  "websearch_balance_required",
+  "both_balance_required",
+]);
+
+const RATE_LIMIT_ERROR_CODES = new Set([
+  "rate_limit_exceeded",
+  "daily_rpd_limit_exceeded",
+  "daily_usd_limit_exceeded",
+]);
+
+const MODEL_NOT_FOUND_ERROR_CODES = new Set([
+  "model_not_found",
+  "model_not_allowed",
+  "model_not_available",
+]);
+
+const RATE_LIMIT_HINTS = [
+  "rate limit",
+  "too many requests",
+  "quota limit",
+  "usage limit",
+  "automatic quota refresh",
+  "rolling time window",
+  "daily",
+  "weekly",
+  "monthly",
+  "try again",
+  "retry",
+] as const;
+
+const BILLING_HINTS = [
+  "insufficient balance",
+  "insufficient quota",
+  "insufficient credits",
+  "credit balance",
+  "plans & billing",
+  "top up",
+  "add more credits",
+  "payment required",
+  "balance required",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readStatus(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10);
+  }
+  return undefined;
+}
+
+function readRetryAfterSeconds(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function normalizeNanoGptErrorToken(value: string | undefined): string | undefined {
+  return value?.trim().toLowerCase();
+}
+
+function extractLeadingHttpStatus(raw: string): number | undefined {
+  const match = raw.match(/^\s*(?:http\s*)?(\d{3})\b/i);
+  return match?.[1] ? Number.parseInt(match[1], 10) : undefined;
+}
+
+function extractJsonRecord(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidates = [trimmed];
+  const firstBrace = trimmed.indexOf("{");
+  const lastBrace = trimmed.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    candidates.push(trimmed.slice(firstBrace, lastBrace + 1));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (isRecord(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Ignore parse failures and keep trying narrower candidates.
+    }
+  }
+
+  return null;
+}
+
+function looksLikeNanoGptErrorishRecord(value: Record<string, unknown>): boolean {
+  return ["error", "message", "status", "type", "code"].some((key) => key in value);
+}
+
+function parseRecognizedNanoGptError(raw: string): NanoGptRecognizedError | null {
+  const statusFromLeadingText = extractLeadingHttpStatus(raw);
+  const record = extractJsonRecord(raw);
+  if (!record) {
+    return null;
+  }
+
+  if (isRecord(record.error)) {
+    const nested = record.error;
+    const message = readString(nested.message);
+    const type = readString(nested.type);
+    const code = readString(nested.code);
+    const param = readString(nested.param);
+    if (message || type || code || param) {
+      return {
+        envelope: record.type === "error" ? "anthropic" : "openai",
+        status: readStatus(record.status) ?? statusFromLeadingText,
+        type,
+        code,
+        message,
+        param,
+        retryAfterSeconds:
+          readRetryAfterSeconds(nested.retryAfter) ??
+          readRetryAfterSeconds(nested.retry_after) ??
+          readRetryAfterSeconds(record.retryAfter) ??
+          readRetryAfterSeconds(record.retry_after),
+        raw,
+      };
+    }
+  }
+
+  if (typeof record.error === "string" || typeof record.message === "string") {
+    const legacyMessage = readString(record.error) ?? readString(record.message);
+    const legacyStatus = readStatus(record.status) ?? statusFromLeadingText;
+    if (legacyMessage) {
+      return {
+        envelope: "legacy",
+        status: legacyStatus,
+        message: legacyMessage,
+        type: readString(record.type),
+        code: readString(record.code),
+        param: readString(record.param),
+        retryAfterSeconds:
+          readRetryAfterSeconds(record.retryAfter) ?? readRetryAfterSeconds(record.retry_after),
+        raw,
+      };
+    }
+  }
+
+  const sseMessage = readString(record.message);
+  const sseStatus = readStatus(record.status) ?? statusFromLeadingText;
+  const sseCode = readString(record.code);
+  if (sseMessage || sseCode) {
+    return {
+      envelope: "sse",
+      status: sseStatus,
+      message: sseMessage,
+      type: readString(record.type),
+      code: sseCode,
+      param: readString(record.param),
+      retryAfterSeconds:
+        readRetryAfterSeconds(record.retryAfter) ?? readRetryAfterSeconds(record.retry_after),
+      raw,
+    };
+  }
+
+  return null;
+}
+
+function parseUnknownNanoGptStructuredError(raw: string): NanoGptUnknownStructuredError | null {
+  const statusFromLeadingText = extractLeadingHttpStatus(raw);
+  const record = extractJsonRecord(raw);
+  if (!record || !looksLikeNanoGptErrorishRecord(record)) {
+    return null;
+  }
+
+  const nested = isRecord(record.error) ? record.error : undefined;
+  return {
+    envelope: "unknown_structured",
+    status: readStatus(record.status) ?? readStatus(nested?.status) ?? statusFromLeadingText,
+    type: readString(nested?.type) ?? readString(record.type),
+    code: readString(nested?.code) ?? readString(record.code),
+    message:
+      readString(nested?.message) ??
+      readString(record.message) ??
+      readString(record.error),
+    jsonKeys: Object.keys(record).sort(),
+    raw,
+  };
+}
+
+function includesAnyHint(value: string, hints: readonly string[]): boolean {
+  return hints.some((hint) => value.includes(hint));
+}
+
+function hasBillingSignal(error: {
+  code?: string;
+  message?: string;
+  status?: number;
+}): boolean {
+  const normalizedCode = normalizeNanoGptErrorToken(error.code);
+  if (normalizedCode && BILLING_ERROR_CODES.has(normalizedCode)) {
+    return true;
+  }
+
+  const normalizedMessage = normalizeNanoGptErrorToken(error.message);
+  if (normalizedMessage && includesAnyHint(normalizedMessage, BILLING_HINTS)) {
+    return true;
+  }
+
+  return error.status === 402 && normalizedMessage === "insufficient balance";
+}
+
+function hasRateLimitSignal(error: {
+  code?: string;
+  message?: string;
+  status?: number;
+}): boolean {
+  const normalizedCode = normalizeNanoGptErrorToken(error.code);
+  if (normalizedCode && RATE_LIMIT_ERROR_CODES.has(normalizedCode)) {
+    return true;
+  }
+
+  const normalizedMessage = normalizeNanoGptErrorToken(error.message);
+  if (normalizedMessage && includesAnyHint(normalizedMessage, RATE_LIMIT_HINTS)) {
+    return true;
+  }
+
+  return error.status === 429;
+}
+
+function mapNanoGptRecognizedError(
+  error: NanoGptRecognizedError,
+): NanoGptFailoverReason | "context_overflow" | null {
+  const normalizedCode = normalizeNanoGptErrorToken(error.code);
+  const normalizedType = normalizeNanoGptErrorToken(error.type);
+
+  if (normalizedCode === "context_length_exceeded") {
+    return "context_overflow";
+  }
+  if (normalizedCode && FORMAT_ERROR_CODES.has(normalizedCode)) {
+    return "format";
+  }
+  if (normalizedCode && BILLING_ERROR_CODES.has(normalizedCode)) {
+    return "billing";
+  }
+  if (normalizedCode && RATE_LIMIT_ERROR_CODES.has(normalizedCode)) {
+    return "rate_limit";
+  }
+  if (normalizedCode && MODEL_NOT_FOUND_ERROR_CODES.has(normalizedCode)) {
+    return "model_not_found";
+  }
+  if (normalizedCode === "all_fallbacks_failed") {
+    return null;
+  }
+
+  if (normalizedType === "authentication_error") {
+    return "auth";
+  }
+  if (normalizedType === "permission_denied_error" || normalizedType === "permission_error") {
+    return "auth";
+  }
+  if (normalizedType === "not_found_error") {
+    return "model_not_found";
+  }
+  if (normalizedType === "rate_limit_error") {
+    return "rate_limit";
+  }
+  if (normalizedType === "service_unavailable") {
+    return "overloaded";
+  }
+  if (normalizedType === "invalid_request_error") {
+    return "format";
+  }
+  if (normalizedType === "server_error" || normalizedType === "api_error") {
+    return error.status === 503 ? "overloaded" : "timeout";
+  }
+
+  switch (error.status) {
+    case 400:
+    case 413:
+    case 422:
+      return "format";
+    case 401:
+      return "auth";
+    case 402:
+      if (hasBillingSignal(error)) {
+        return "billing";
+      }
+      if (hasRateLimitSignal(error)) {
+        return "rate_limit";
+      }
+      return null;
+    case 403:
+      return "auth";
+    case 404:
+      return "model_not_found";
+    case 408:
+    case 504:
+      return "timeout";
+    case 429:
+      return "rate_limit";
+    case 500:
+      return "timeout";
+    case 503:
+      return "overloaded";
+    default:
+      return null;
+  }
+}
+
+export function inspectNanoGptErrorSurface(raw: string): NanoGptErrorSurfaceInspection | null {
+  const recognized = parseRecognizedNanoGptError(raw);
+  if (recognized) {
+    const mapped = mapNanoGptRecognizedError(recognized);
+    if (mapped === "context_overflow") {
+      return {
+        kind: "context_overflow",
+        error: recognized,
+      };
+    }
+    if (mapped) {
+      return {
+        kind: "mapped",
+        reason: mapped,
+        error: recognized,
+      };
+    }
+    return {
+      kind: "recognized_unmapped",
+      error: recognized,
+    };
+  }
+
+  const unknown = parseUnknownNanoGptStructuredError(raw);
+  if (unknown) {
+    return {
+      kind: "unknown_structured",
+      error: unknown,
+    };
+  }
+
+  return null;
+}
+
+export function formatNanoGptErrorSurfaceDetails(error: {
+  envelope: string;
+  status?: number;
+  type?: string;
+  code?: string;
+  param?: string;
+  retryAfterSeconds?: number;
+}): string {
+  const parts = [`envelope=${error.envelope}`];
+  if (typeof error.status === "number") {
+    parts.push(`status=${error.status}`);
+  }
+  if (error.type) {
+    parts.push(`type=${error.type}`);
+  }
+  if (error.code) {
+    parts.push(`code=${error.code}`);
+  }
+  if (error.param) {
+    parts.push(`param=${error.param}`);
+  }
+  if (typeof error.retryAfterSeconds === "number") {
+    parts.push(`retryAfter=${error.retryAfterSeconds}s`);
+  }
+  return parts.join(", ");
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "runtime.ts",
     "provider-catalog.ts",
     "provider-discovery.ts",
+    "nanogpt-errors.ts",
     "image-generation-provider.ts",
     "web-search.ts",
     "onboard.ts",


### PR DESCRIPTION
## Summary

This PR implements a structured NanoGPT error surface for the provider hook path instead of relying only on broad raw-string matching.

It adds NanoGPT-aware parsing and mapping into established OpenClaw failover buckets where we can do so confidently, while preserving OpenClaw's generic fallback classifier for anything recognized-but-unmapped or entirely unknown.

## What Changed

- added `nanogpt-errors.ts` to parse documented NanoGPT error envelopes and map them to OpenClaw reasons
- wired provider-owned `classifyFailoverReason` logging and fallthrough in `index.ts`
- wired provider-owned `matchesContextOverflowError` handling for `context_length_exceeded`
- added regression coverage for mapped, unmapped, unknown, and context-overflow cases
- updated the package surface to ship the new helper

## Why

Issue #85 reported intermittent Kimi billing-style failures that may not all be true balance problems.

Before this change, the plugin emitted a broad NanoGPT-specific billing warning on `402`-looking failures and otherwise relied on generic OpenClaw heuristics. That made weird NanoGPT behavior harder to debug and risked describing transient or routing-shaped failures as billing.

This change makes the plugin:

- map NanoGPT responses to OpenClaw-established patterns when possible
- warn loudly for structured NanoGPT errors that cannot be mapped confidently
- warn loudly for unknown NanoGPT-shaped responses
- fall back to OpenClaw's generic classifier instead of prematurely forcing `unknown`

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`

Closes #85.
