### PR TITLE
Enhance streaming usage tracking and add tests for usage warnings

### DIFF
--- a/docs/issues/2026-04-22-issue-88-context-usage-unknown.md
+++ b/docs/issues/2026-04-22-issue-88-context-usage-unknown.md
@@ -1,0 +1,73 @@
+# Issue 88: `/status` shows `?/200k` for `nanogpt/openai/gpt-5.4-mini`
+
+**Issue:** https://github.com/deadronos/nanogpt-provider-openclaw/issues/88  
+**Date:** 2026-04-22
+
+## Symptom
+
+One user reported OpenClaw’s `/status` context usage showing `?/200k` when using the NanoGPT model id:
+
+- `nanogpt/openai/gpt-5.4-mini`
+
+but showing a normal “used/max” number for other NanoGPT models (example families mentioned: GLM, Kimi).
+
+Interpretation: OpenClaw knows the model’s **max context window** (here: `200k`), but does not have a reliable “tokens used” value for the current session/turn, so it prints `?` for the numerator.
+
+## How this can happen (in this plugin)
+
+This repository does **not** compute tokens client-side. It relies on OpenClaw’s normal usage pipeline for OpenAI-compatible streaming transports:
+
+- When OpenClaw believes a model supports “usage in streaming”, it adds `stream_options.include_usage: true` on OpenAI Chat Completions streams.
+- If the upstream stream includes a final usage-only SSE chunk, OpenClaw can track prompt/completion token usage and `/status` displays a concrete numerator.
+- If the upstream stream does **not** include usage (or it is not parseable by OpenClaw), OpenClaw can only display the denominator (`contextWindow`) and prints `?/<contextWindow>`.
+
+### 1) `supportsUsageInStreaming` compat is only patched for `openai-completions`
+
+The NanoGPT plugin opts completions-mode models into streaming usage compat via:
+
+- `provider/catalog-hooks.ts` → `applyNanoGptNativeStreamingUsageCompat(...)`
+
+That patch only applies when `providerConfig.api === "openai-completions"`. If the NanoGPT provider is configured to use the Responses transport (`requestApi: "responses"`), this patch is skipped, meaning OpenClaw may never request `stream_options.include_usage` for those turns.
+
+In that case, if NanoGPT does not include usage by default on streams, `/status` can display `?/200k`.
+
+### 2) An explicit `supportsUsageInStreaming: false` is preserved
+
+`applyNanoGptNativeStreamingUsageCompat(...)` intentionally does **not** override an explicit `compat.supportsUsageInStreaming` value.
+
+So if the user’s generated `<agentDir>/models.json` (or another config source) sets:
+
+- `compat.supportsUsageInStreaming: false`
+
+for `openai/gpt-5.4-mini`, then OpenClaw will not request `stream_options.include_usage` and the numerator may remain unknown (`?`).
+
+### 3) NanoGPT may not emit usage for some upstream providers/models (even when requested)
+
+Even if OpenClaw requests `stream_options.include_usage`, OpenClaw can only show a concrete numerator if the NanoGPT upstream stream actually includes a usage payload.
+
+It’s plausible (and consistent with the report) that NanoGPT:
+
+- emits usage for some upstream providers/models (GLM, Kimi, …), but
+- does not emit usage for `openai/gpt-5.4-mini` on the chosen routing/transport path.
+
+This repo currently does not add a NanoGPT-specific SSE parser or a post-hoc usage reconciliation layer; `wrapStreamFn` is pass-through (`provider/stream-hooks.ts`), so there’s no plugin-side repair for missing usage chunks.
+
+## What to check to confirm the root cause
+
+1) Inspect the generated provider snapshot:
+
+- `<agentDir>/models.json` (see `models.ts` → `resolveNanoGptAgentDir(...)` for how `agentDir` is inferred)
+
+Verify for the `nanogpt` provider:
+
+- `api` is `openai-completions` (vs `openai-responses`)
+- the model entry for `openai/gpt-5.4-mini` does **not** set `compat.supportsUsageInStreaming: false`
+
+2) If `api` is `openai-responses`, confirm whether OpenClaw is emitting usage for Responses streaming at all, and whether NanoGPT forwards it.
+
+3) If `api` is `openai-completions` and `supportsUsageInStreaming` is true, capture one raw streamed response and check whether any SSE chunk contains a `usage` object.
+
+## Notes / likely next steps
+
+- If the issue is “NanoGPT does not return usage in streaming for that model”, this plugin can’t invent correct token counts without implementing client-side tokenization (out of scope for the current design).
+- A mitigation is to force `stream_options.include_usage` on NanoGPT completions streams (unless a model explicitly sets `compat.supportsUsageInStreaming: false`), and emit a loud-but-nonblocking warning if the final streamed result still has empty/invalid usage. This makes the “missing usage” failure mode visible in OpenClaw logs without breaking requests.

--- a/index.ts
+++ b/index.ts
@@ -79,7 +79,7 @@ export default definePluginEntry({
         applyNanoGptNativeStreamingUsageCompat(providerConfig),
       resolveUsageAuth: async (ctx) => await resolveNanoGptUsageAuth(ctx),
       fetchUsageSnapshot: async (ctx) => await fetchNanoGptUsageSnapshot(ctx),
-      wrapStreamFn: (ctx) => wrapNanoGptStreamFn(ctx),
+      wrapStreamFn: (ctx) => wrapNanoGptStreamFn(ctx, api.logger),
       matchesContextOverflowError: (ctx) => matchesContextOverflowErrorHook(ctx),
       classifyFailoverReason: (ctx) => classifyFailoverReasonHook(ctx),
     });

--- a/provider/stream-hooks.test.ts
+++ b/provider/stream-hooks.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantMessageEventStream, type AssistantMessage } from "@mariozechner/pi-ai";
+import { wrapNanoGptStreamFn } from "./stream-hooks.js";
+
+describe("nanoGPT stream hooks", () => {
+  it("forces stream_options.include_usage for completions streams and warns when usage is empty", async () => {
+    const warn = vi.fn();
+    let observedPayload: unknown;
+
+    const baseStreamFn = vi.fn(async (_model: unknown, _context: unknown, options?: any) => {
+      if (typeof options?.onPayload === "function") {
+        observedPayload = await options.onPayload({ stream: true }, {});
+      }
+
+      const stream = createAssistantMessageEventStream();
+      const message: AssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        api: "openai-completions",
+        provider: "nanogpt",
+        model: "openai/gpt-5.4-mini",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      };
+      stream.push({ type: "done", reason: "stop", message });
+      stream.end(message);
+      return stream;
+    });
+
+    const wrapped = wrapNanoGptStreamFn(
+      {
+        provider: "nanogpt",
+        modelId: "openai/gpt-5.4-mini",
+        extraParams: {},
+        model: {
+          id: "openai/gpt-5.4-mini",
+          api: "openai-completions",
+          compat: {},
+        },
+        streamFn: baseStreamFn,
+      } as any,
+      { warn },
+    );
+
+    expect(wrapped).toEqual(expect.any(Function));
+    const stream = await wrapped?.({} as any, {} as any, {});
+    await stream?.result();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(observedPayload).toMatchObject({
+      stream_options: {
+        include_usage: true,
+      },
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not override supportsUsageInStreaming=false", () => {
+    const warn = vi.fn();
+    const baseStreamFn = vi.fn();
+
+    const wrapped = wrapNanoGptStreamFn(
+      {
+        provider: "nanogpt",
+        modelId: "openai/gpt-5.4-mini",
+        extraParams: {},
+        model: {
+          id: "openai/gpt-5.4-mini",
+          api: "openai-completions",
+          compat: { supportsUsageInStreaming: false },
+        },
+        streamFn: baseStreamFn,
+      } as any,
+      { warn },
+    );
+
+    expect(wrapped).toBe(baseStreamFn);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+

--- a/provider/stream-hooks.ts
+++ b/provider/stream-hooks.ts
@@ -1,12 +1,199 @@
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { isRecord } from "../shared/guards.js";
 
 type NanoGptWrappedStreamFn = ProviderWrapStreamFnContext["streamFn"];
 
+type NanoGptLogger = {
+  warn?: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+type NanoGptUsage = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+};
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function inspectUsage(usage: unknown): { empty: boolean; invalidFields: string[] } {
+  if (!isRecord(usage)) {
+    return { empty: true, invalidFields: ["usage"] };
+  }
+
+  const invalidFields: string[] = [];
+  const numericFields: Array<keyof NanoGptUsage> = [
+    "input",
+    "output",
+    "cacheRead",
+    "cacheWrite",
+    "totalTokens",
+  ];
+  for (const field of numericFields) {
+    if (!isFiniteNonNegativeNumber(usage[field])) {
+      invalidFields.push(`usage.${field}`);
+    }
+  }
+
+  if (!isRecord(usage.cost)) {
+    invalidFields.push("usage.cost");
+  } else {
+    const costFields: Array<keyof NanoGptUsage["cost"]> = [
+      "input",
+      "output",
+      "cacheRead",
+      "cacheWrite",
+      "total",
+    ];
+    for (const field of costFields) {
+      if (!isFiniteNonNegativeNumber(usage.cost[field])) {
+        invalidFields.push(`usage.cost.${field}`);
+      }
+    }
+  }
+
+  const empty =
+    invalidFields.length === 0 &&
+    usage.input === 0 &&
+    usage.output === 0 &&
+    usage.cacheRead === 0 &&
+    usage.cacheWrite === 0 &&
+    usage.totalTokens === 0 &&
+    isRecord(usage.cost) &&
+    usage.cost.input === 0 &&
+    usage.cost.output === 0 &&
+    usage.cost.cacheRead === 0 &&
+    usage.cost.cacheWrite === 0 &&
+    usage.cost.total === 0;
+
+  return { empty, invalidFields };
+}
+
+function ensureIncludeUsageInStreamingPayload(payload: unknown): { payload?: unknown; requested: boolean } {
+  if (!isRecord(payload)) {
+    return { requested: false };
+  }
+
+  const streamValue = payload.stream;
+  const isStreaming = streamValue === true || streamValue === "true";
+  const hasStreamOptionsKey = "stream_options" in payload;
+  if (!isStreaming && !hasStreamOptionsKey) {
+    return { requested: false };
+  }
+
+  const existingStreamOptions = isRecord(payload.stream_options) ? payload.stream_options : undefined;
+  const existingIncludeUsage = existingStreamOptions?.include_usage;
+  if (existingIncludeUsage === true) {
+    return { requested: true };
+  }
+
+  return {
+    requested: true,
+    payload: {
+      ...payload,
+      stream_options: {
+        ...(existingStreamOptions ? existingStreamOptions : {}),
+        include_usage: true,
+      },
+    },
+  };
+}
+
+function scheduleUsageInStreamingWarning(params: {
+  stream: unknown;
+  logger?: NanoGptLogger;
+  modelId: string;
+  requestedIncludeUsage: boolean;
+}): void {
+  if (!params.requestedIncludeUsage) {
+    return;
+  }
+
+  if (!params.stream || typeof (params.stream as any).result !== "function") {
+    return;
+  }
+
+  void (params.stream as any)
+    .result()
+    .then((finalMessage: unknown) => {
+      if (!isRecord(finalMessage)) {
+        return;
+      }
+      const { empty, invalidFields } = inspectUsage(finalMessage.usage);
+      if (!empty && invalidFields.length === 0) {
+        return;
+      }
+      params.logger?.warn?.(
+        `[nanogpt] requested stream_options.include_usage but received ${empty ? "empty" : "invalid"} usage in stream result`,
+        {
+          modelId: params.modelId,
+          ...(invalidFields.length > 0 ? { invalidFields } : {}),
+        },
+      );
+    })
+    .catch(() => {
+      // Non-blocking: usage warning is best-effort.
+    });
+}
+
 export function wrapNanoGptStreamFn(
   ctx: ProviderWrapStreamFnContext,
+  logger?: NanoGptLogger,
 ): NanoGptWrappedStreamFn {
   if (ctx.streamFn) {
-    return ctx.streamFn;
+    const streamFn = ctx.streamFn;
+    const modelApi = ctx.model?.api;
+    if (modelApi !== "openai-completions") {
+      return streamFn;
+    }
+
+    const modelCompat = ctx.model?.compat;
+    if (isRecord(modelCompat) && "supportsUsageInStreaming" in modelCompat) {
+      if (modelCompat.supportsUsageInStreaming === false) {
+        return streamFn;
+      }
+    }
+
+    return async (model, context, options) => {
+      let requestedIncludeUsage = false;
+      const upstreamOnPayload = options?.onPayload;
+      const patchedOptions = {
+        ...(options ?? {}),
+        onPayload: async (payload: unknown, payloadModel: unknown) => {
+          const upstreamPayload =
+            typeof upstreamOnPayload === "function"
+              ? ((await upstreamOnPayload(payload, payloadModel as never)) ?? payload)
+              : payload;
+
+          const ensured = ensureIncludeUsageInStreamingPayload(upstreamPayload);
+          if (ensured.requested) {
+            requestedIncludeUsage = true;
+          }
+          return ensured.payload ?? upstreamPayload;
+        },
+      };
+
+      const stream = await streamFn(model, context, patchedOptions);
+
+      scheduleUsageInStreamingWarning({
+        stream,
+        logger,
+        modelId: ctx.model?.id ?? ctx.modelId,
+        requestedIncludeUsage,
+      });
+
+      return stream as any;
+    };
   }
   return undefined;
 }


### PR DESCRIPTION
Improve tracking of streaming usage by ensuring that the `stream_options.include_usage` is set for completions streams and add tests to verify the functionality. This addresses the issue of missing usage data in the `/status` endpoint for specific models.