### PR TITLE
refactor: granular file split — extract markers, inspection, subscription helpers

### DIFF
--- a/nanogpt-errors.ts
+++ b/nanogpt-errors.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "./shared/guards.js";
+
 type NanoGptFailoverReason =
   | "auth"
   | "auth_permanent"
@@ -109,10 +111,6 @@ const BILLING_HINTS = [
   "payment required",
   "balance required",
 ] as const;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function readString(value: unknown): string | undefined {
   if (typeof value !== "string") {

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/provider/inspection.ts
+++ b/provider/inspection.ts
@@ -1,0 +1,49 @@
+import {
+  NANO_GPT_REASONING_TAG_PAIRS,
+  NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS,
+  NANO_GPT_FUNCTION_CALL_MARKERS,
+  countNanoGptSubstringOccurrences,
+} from "./markers.js";
+
+export type NanoGptStreamMarkerInspection = Readonly<{
+  reasoningMarkerNames: readonly string[];
+  reasoningIsUnbalanced: boolean;
+  xmlLikeToolWrapperMarkers: readonly string[];
+  functionCallMarkers: readonly string[];
+  toolLikeMarkers: readonly string[];
+}>;
+
+export function collectNanoGptStreamMarkerInspection(visibleText: string): NanoGptStreamMarkerInspection {
+  const normalizedVisibleText = visibleText.toLowerCase();
+  const reasoningMarkerNames = new Set<string>();
+  let reasoningIsUnbalanced = false;
+
+  for (const tagPair of NANO_GPT_REASONING_TAG_PAIRS) {
+    const openTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.open);
+    const closeTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.close);
+    if (openTagCount === 0 && closeTagCount === 0) {
+      continue;
+    }
+
+    reasoningMarkerNames.add(tagPair.open);
+    reasoningMarkerNames.add(tagPair.close);
+    if (openTagCount !== closeTagCount) {
+      reasoningIsUnbalanced = true;
+    }
+  }
+
+  const xmlLikeToolWrapperMarkers = NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS.filter((marker) =>
+    normalizedVisibleText.includes(marker),
+  );
+  const functionCallMarkers = NANO_GPT_FUNCTION_CALL_MARKERS.filter((marker) =>
+    normalizedVisibleText.includes(marker),
+  );
+
+  return {
+    reasoningMarkerNames: [...reasoningMarkerNames],
+    reasoningIsUnbalanced,
+    xmlLikeToolWrapperMarkers,
+    functionCallMarkers,
+    toolLikeMarkers: [...new Set([...xmlLikeToolWrapperMarkers, ...functionCallMarkers])],
+  };
+}

--- a/provider/markers.ts
+++ b/provider/markers.ts
@@ -1,0 +1,36 @@
+export const NANO_GPT_REASONING_TAG_PAIRS = [
+  { open: "<thinking>", close: "</thinking>" },
+  { open: "<reasoning>", close: "</reasoning>" },
+  { open: "<analysis>", close: "</analysis>" },
+] as const;
+
+export const NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS = [
+  "<tool>",
+  "</tool>",
+  "<tool_call>",
+  "</tool_call>",
+  "<tools>",
+  "</tools>",
+  "<invoke>",
+  "</invoke>",
+] as const;
+
+export const NANO_GPT_FUNCTION_CALL_MARKERS = ["<function=", "function="] as const;
+
+export function countNanoGptSubstringOccurrences(haystack: string, needle: string): number {
+  if (!needle) {
+    return 0;
+  }
+
+  const normalizedHaystack = haystack.toLowerCase();
+  const normalizedNeedle = needle.toLowerCase();
+  let count = 0;
+  let index = 0;
+
+  while ((index = normalizedHaystack.indexOf(normalizedNeedle, index)) !== -1) {
+    count += 1;
+    index += normalizedNeedle.length;
+  }
+
+  return count;
+}

--- a/provider/replay-hooks.ts
+++ b/provider/replay-hooks.ts
@@ -8,12 +8,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { buildOpenAICompatibleReplayPolicy } from "openclaw/plugin-sdk/provider-model-shared";
 import { isRecord } from "../shared/guards.js";
-import {
-  NANO_GPT_REASONING_TAG_PAIRS,
-  NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS,
-  NANO_GPT_FUNCTION_CALL_MARKERS,
-  countNanoGptSubstringOccurrences,
-} from "./markers.js";
+import { collectNanoGptStreamMarkerInspection } from "./inspection.js";
 import {
   createNanoGptAnomalyWarnOnceLogger,
   type NanoGptAnomalyWarning,
@@ -183,30 +178,7 @@ function collectNanoGptReplayAssistantInspection(
     }
   }
 
-  const normalizedVisibleText = visibleText.toLowerCase();
-  const reasoningMarkerNames = new Set<string>();
-  let reasoningIsUnbalanced = false;
-
-  for (const tagPair of NANO_GPT_REASONING_TAG_PAIRS) {
-    const openTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.open);
-    const closeTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.close);
-    if (openTagCount === 0 && closeTagCount === 0) {
-      continue;
-    }
-
-    reasoningMarkerNames.add(tagPair.open);
-    reasoningMarkerNames.add(tagPair.close);
-    if (openTagCount !== closeTagCount) {
-      reasoningIsUnbalanced = true;
-    }
-  }
-
-  const xmlLikeToolWrapperMarkers = NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS.filter((marker) =>
-    normalizedVisibleText.includes(marker),
-  );
-  const functionCallMarkers = NANO_GPT_FUNCTION_CALL_MARKERS.filter((marker) =>
-    normalizedVisibleText.includes(marker),
-  );
+  const markerInspection = collectNanoGptStreamMarkerInspection(visibleText);
 
   return {
     visibleText,
@@ -216,11 +188,11 @@ function collectNanoGptReplayAssistantInspection(
     toolCallCount,
     toolCalls,
     toolCallNames: [...toolCallNames],
-    reasoningMarkerNames: [...reasoningMarkerNames],
-    reasoningIsUnbalanced,
-    xmlLikeToolWrapperMarkers,
-    functionCallMarkers,
-    toolLikeMarkers: [...new Set([...xmlLikeToolWrapperMarkers, ...functionCallMarkers])],
+    reasoningMarkerNames: markerInspection.reasoningMarkerNames,
+    reasoningIsUnbalanced: markerInspection.reasoningIsUnbalanced,
+    xmlLikeToolWrapperMarkers: markerInspection.xmlLikeToolWrapperMarkers,
+    functionCallMarkers: markerInspection.functionCallMarkers,
+    toolLikeMarkers: markerInspection.toolLikeMarkers,
     missingToolCallIdCount,
     duplicateToolCallIdCount,
   };

--- a/provider/replay-hooks.ts
+++ b/provider/replay-hooks.ts
@@ -9,6 +9,12 @@ import type {
 import { buildOpenAICompatibleReplayPolicy } from "openclaw/plugin-sdk/provider-model-shared";
 import { isRecord } from "../shared/guards.js";
 import {
+  NANO_GPT_REASONING_TAG_PAIRS,
+  NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS,
+  NANO_GPT_FUNCTION_CALL_MARKERS,
+  countNanoGptSubstringOccurrences,
+} from "./markers.js";
+import {
   createNanoGptAnomalyWarnOnceLogger,
   type NanoGptAnomalyWarning,
   type NanoGptWarnLogger,
@@ -76,46 +82,9 @@ const NANO_GPT_REPLAY_WARNING_LOGGER_CACHE = new WeakMap<
   NanoGptReplayWarnFn
 >();
 
-const NANO_GPT_REASONING_TAG_PAIRS = [
-  { open: "<thinking>", close: "</thinking>" },
-  { open: "<reasoning>", close: "</reasoning>" },
-  { open: "<analysis>", close: "</analysis>" },
-] as const;
-
-const NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS = [
-  "<tool>",
-  "</tool>",
-  "<tool_call>",
-  "</tool_call>",
-  "<tools>",
-  "</tools>",
-  "<invoke>",
-  "</invoke>",
-] as const;
-
-const NANO_GPT_FUNCTION_CALL_MARKERS = ["<function=", "function="] as const;
-
 function normalizeNanoGptReplayText(value: string | undefined): string | undefined {
   const normalized = value?.replace(/\s+/g, " ").trim();
   return normalized ? normalized : undefined;
-}
-
-function countNanoGptReplaySubstringOccurrences(haystack: string, needle: string): number {
-  if (!needle) {
-    return 0;
-  }
-
-  const normalizedHaystack = haystack.toLowerCase();
-  const normalizedNeedle = needle.toLowerCase();
-  let count = 0;
-  let index = 0;
-
-  while ((index = normalizedHaystack.indexOf(normalizedNeedle, index)) !== -1) {
-    count += 1;
-    index += normalizedNeedle.length;
-  }
-
-  return count;
 }
 
 function isNanoGptAssistantReplayMessage(message: unknown): message is {
@@ -219,8 +188,8 @@ function collectNanoGptReplayAssistantInspection(
   let reasoningIsUnbalanced = false;
 
   for (const tagPair of NANO_GPT_REASONING_TAG_PAIRS) {
-    const openTagCount = countNanoGptReplaySubstringOccurrences(normalizedVisibleText, tagPair.open);
-    const closeTagCount = countNanoGptReplaySubstringOccurrences(normalizedVisibleText, tagPair.close);
+    const openTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.open);
+    const closeTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.close);
     if (openTagCount === 0 && closeTagCount === 0) {
       continue;
     }

--- a/provider/stream-hooks.ts
+++ b/provider/stream-hooks.ts
@@ -16,6 +16,10 @@ import {
   NANO_GPT_FUNCTION_CALL_MARKERS,
   countNanoGptSubstringOccurrences,
 } from "./markers.js";
+import {
+  collectNanoGptStreamMarkerInspection,
+  type NanoGptStreamMarkerInspection,
+} from "./inspection.js";
 
 type NanoGptWrappedStreamFn = ProviderWrapStreamFnContext["streamFn"];
 
@@ -35,14 +39,6 @@ type NanoGptStreamContentInspection = Readonly<{
   textBlockCount: number;
   toolCallCount: number;
   thinkingBlockCount: number;
-}>;
-
-type NanoGptStreamMarkerInspection = Readonly<{
-  reasoningMarkerNames: readonly string[];
-  reasoningIsUnbalanced: boolean;
-  xmlLikeToolWrapperMarkers: readonly string[];
-  functionCallMarkers: readonly string[];
-  toolLikeMarkers: readonly string[];
 }>;
 
 type NanoGptUsage = {
@@ -132,41 +128,6 @@ function collectNanoGptStreamContentInspection(finalMessage: unknown): NanoGptSt
     textBlockCount,
     toolCallCount,
     thinkingBlockCount,
-  };
-}
-
-function collectNanoGptStreamMarkerInspection(visibleText: string): NanoGptStreamMarkerInspection {
-  const normalizedVisibleText = visibleText.toLowerCase();
-  const reasoningMarkerNames = new Set<string>();
-  let reasoningIsUnbalanced = false;
-
-  for (const tagPair of NANO_GPT_REASONING_TAG_PAIRS) {
-    const openTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.open);
-    const closeTagCount = countNanoGptSubstringOccurrences(normalizedVisibleText, tagPair.close);
-    if (openTagCount === 0 && closeTagCount === 0) {
-      continue;
-    }
-
-    reasoningMarkerNames.add(tagPair.open);
-    reasoningMarkerNames.add(tagPair.close);
-    if (openTagCount !== closeTagCount) {
-      reasoningIsUnbalanced = true;
-    }
-  }
-
-  const xmlLikeToolWrapperMarkers = NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS.filter((marker) =>
-    normalizedVisibleText.includes(marker),
-  );
-  const functionCallMarkers = NANO_GPT_FUNCTION_CALL_MARKERS.filter((marker) =>
-    normalizedVisibleText.includes(marker),
-  );
-
-  return {
-    reasoningMarkerNames: [...reasoningMarkerNames],
-    reasoningIsUnbalanced,
-    xmlLikeToolWrapperMarkers,
-    functionCallMarkers,
-    toolLikeMarkers: [...new Set([...xmlLikeToolWrapperMarkers, ...functionCallMarkers])],
   };
 }
 

--- a/provider/stream-hooks.ts
+++ b/provider/stream-hooks.ts
@@ -10,6 +10,12 @@ import {
   type NanoGptModelFamily,
 } from "./anomaly-types.js";
 import { isRecord } from "../shared/guards.js";
+import {
+  NANO_GPT_REASONING_TAG_PAIRS,
+  NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS,
+  NANO_GPT_FUNCTION_CALL_MARKERS,
+  countNanoGptSubstringOccurrences,
+} from "./markers.js";
 
 type NanoGptWrappedStreamFn = ProviderWrapStreamFnContext["streamFn"];
 
@@ -58,43 +64,6 @@ const NANO_GPT_STREAM_ANOMALY_LOGGER_CACHE = new WeakMap<
   NanoGptLogger,
   (warning: NanoGptAnomalyWarning) => void
 >();
-
-const NANO_GPT_REASONING_TAG_PAIRS = [
-  { open: "<thinking>", close: "</thinking>" },
-  { open: "<reasoning>", close: "</reasoning>" },
-  { open: "<analysis>", close: "</analysis>" },
-] as const;
-
-const NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS = [
-  "<tool>",
-  "</tool>",
-  "<tool_call>",
-  "</tool_call>",
-  "<tools>",
-  "</tools>",
-  "<invoke>",
-  "</invoke>",
-] as const;
-
-const NANO_GPT_FUNCTION_CALL_MARKERS = ["<function=", "function="] as const;
-
-function countNanoGptSubstringOccurrences(haystack: string, needle: string): number {
-  if (!needle) {
-    return 0;
-  }
-
-  const normalizedHaystack = haystack.toLowerCase();
-  const normalizedNeedle = needle.toLowerCase();
-  let count = 0;
-  let index = 0;
-
-  while ((index = normalizedHaystack.indexOf(normalizedNeedle, index)) !== -1) {
-    count += 1;
-    index += normalizedNeedle.length;
-  }
-
-  return count;
-}
 
 function collectNanoGptRequestToolMetadata(context: unknown): NanoGptRequestToolMetadata {
   if (!isRecord(context) || !Array.isArray(context.tools)) {

--- a/runtime/routing.ts
+++ b/runtime/routing.ts
@@ -8,87 +8,15 @@ import {
   type NanoGptRoutingMode,
 } from "../models.js";
 import { sanitizeApiKey, sanitizeHeaderValue } from "../shared/http.js";
+import {
+  resolveNanoGptSubscriptionActive,
+  type NanoGptSubscriptionPayload,
+} from "./subscription.js";
 
 const SUBSCRIPTION_CACHE_TTL_MS = 60_000;
 export const NANOGPT_SUBSCRIPTION_PROBE_TIMEOUT_MS = 10_000;
 
 const subscriptionCache = new Map<string, { active: boolean; expiresAt: number }>();
-
-type NanoGptSubscriptionPayload = {
-  subscribed?: unknown;
-  active?: unknown;
-  state?: unknown;
-  plan?: unknown;
-  graceUntil?: unknown;
-};
-
-function resolveNanoGptSubscriptionState(value: unknown): boolean | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-
-  if (
-    normalized === "active" ||
-    normalized === "subscribed" ||
-    normalized === "grace" ||
-    normalized === "grace_period" ||
-    normalized === "grace-period" ||
-    normalized === "trial" ||
-    normalized === "trialing"
-  ) {
-    return true;
-  }
-
-  if (
-    normalized === "inactive" ||
-    normalized === "expired" ||
-    normalized === "unsubscribed" ||
-    normalized === "cancelled" ||
-    normalized === "canceled" ||
-    normalized === "none"
-  ) {
-    return false;
-  }
-
-  return undefined;
-}
-
-function hasNanoGptFutureGracePeriod(value: unknown): boolean {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value > Date.now();
-  }
-  if (typeof value === "string" && value.trim()) {
-    const parsed = Date.parse(value.trim());
-    return Number.isFinite(parsed) && parsed > Date.now();
-  }
-  return false;
-}
-
-function resolveNanoGptSubscriptionActive(payload: NanoGptSubscriptionPayload): boolean {
-  const subscribed = typeof payload.subscribed === "boolean" ? payload.subscribed : undefined;
-  const active = typeof payload.active === "boolean" ? payload.active : undefined;
-  const state = resolveNanoGptSubscriptionState(payload.state);
-  const plan = resolveNanoGptSubscriptionState(payload.plan);
-
-  if (subscribed === true || active === true || state === true || plan === true) {
-    return true;
-  }
-
-  if (hasNanoGptFutureGracePeriod(payload.graceUntil)) {
-    return true;
-  }
-
-  if (subscribed === false || active === false || state === false || plan === false) {
-    return false;
-  }
-
-  return false;
-}
 
 export async function probeNanoGptSubscription(apiKey: string): Promise<boolean> {
   const now = Date.now();

--- a/runtime/subscription.ts
+++ b/runtime/subscription.ts
@@ -1,0 +1,75 @@
+export type NanoGptSubscriptionPayload = {
+  subscribed?: unknown;
+  active?: unknown;
+  state?: unknown;
+  plan?: unknown;
+  graceUntil?: unknown;
+};
+
+export function resolveNanoGptSubscriptionState(value: unknown): boolean | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (
+    normalized === "active" ||
+    normalized === "subscribed" ||
+    normalized === "grace" ||
+    normalized === "grace_period" ||
+    normalized === "grace-period" ||
+    normalized === "trial" ||
+    normalized === "trialing"
+  ) {
+    return true;
+  }
+
+  if (
+    normalized === "inactive" ||
+    normalized === "expired" ||
+    normalized === "unsubscribed" ||
+    normalized === "cancelled" ||
+    normalized === "canceled" ||
+    normalized === "none"
+  ) {
+    return false;
+  }
+
+  return undefined;
+}
+
+export function hasNanoGptFutureGracePeriod(value: unknown): boolean {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > Date.now();
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value.trim());
+    return Number.isFinite(parsed) && parsed > Date.now();
+  }
+  return false;
+}
+
+export function resolveNanoGptSubscriptionActive(payload: NanoGptSubscriptionPayload): boolean {
+  const subscribed = typeof payload.subscribed === "boolean" ? payload.subscribed : undefined;
+  const active = typeof payload.active === "boolean" ? payload.active : undefined;
+  const state = resolveNanoGptSubscriptionState(payload.state);
+  const plan = resolveNanoGptSubscriptionState(payload.plan);
+
+  if (subscribed === true || active === true || state === true || plan === true) {
+    return true;
+  }
+
+  if (hasNanoGptFutureGracePeriod(payload.graceUntil)) {
+    return true;
+  }
+
+  if (subscribed === false || active === false || state === false || plan === false) {
+    return false;
+  }
+
+  return false;
+}

--- a/runtime/usage.ts
+++ b/runtime/usage.ts
@@ -96,68 +96,6 @@ function resolveNanoGptUsagePlan(payload: NanoGptUsagePayload): string | undefin
   return typeof payload.active === "boolean" ? (payload.active ? "active" : "inactive") : undefined;
 }
 
-function resolveNanoGptSubscriptionState(value: unknown): boolean | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-
-  if (
-    normalized === "active" ||
-    normalized === "subscribed" ||
-    normalized === "grace" ||
-    normalized === "grace_period" ||
-    normalized === "grace-period" ||
-    normalized === "trial" ||
-    normalized === "trialing"
-  ) {
-    return true;
-  }
-
-  if (
-    normalized === "inactive" ||
-    normalized === "expired" ||
-    normalized === "unsubscribed" ||
-    normalized === "cancelled" ||
-    normalized === "canceled" ||
-    normalized === "none"
-  ) {
-    return false;
-  }
-
-  return undefined;
-}
-
-function hasNanoGptFutureGracePeriod(value: unknown): boolean {
-  const graceUntil = parseEpochMillis(value);
-  return typeof graceUntil === "number" && graceUntil > Date.now();
-}
-
-function resolveNanoGptSubscriptionActive(payload: NanoGptUsagePayload): boolean {
-  const subscribed = typeof payload.subscribed === "boolean" ? payload.subscribed : undefined;
-  const active = typeof payload.active === "boolean" ? payload.active : undefined;
-  const state = resolveNanoGptSubscriptionState(payload.state);
-  const plan = resolveNanoGptSubscriptionState(payload.plan);
-
-  if (subscribed === true || active === true || state === true || plan === true) {
-    return true;
-  }
-
-  if (hasNanoGptFutureGracePeriod(payload.graceUntil)) {
-    return true;
-  }
-
-  if (subscribed === false || active === false || state === false || plan === false) {
-    return false;
-  }
-
-  return false;
-}
-
 function buildNanoGptUsageErrorSnapshot(error: string): ProviderUsageSnapshot {
   return {
     provider: NANOGPT_USAGE_PROVIDER_ID as ProviderUsageSnapshot["provider"],


### PR DESCRIPTION
## Summary

Refactor large provider and runtime files into smaller, single-responsibility files. Extract duplicated logic into shared helpers/utils. No behavioral changes.

- **New `provider/markers.ts`**: shared marker constants (`NANO_GPT_REASONING_TAG_PAIRS`, `NANO_GPT_XML_LIKE_TOOL_WRAPPER_MARKERS`, `NANO_GPT_FUNCTION_CALL_MARKERS`) + `countNanoGptSubstringOccurrences` helper
- **New `provider/inspection.ts`**: shared `collectNanoGptStreamMarkerInspection` function extracted from both `replay-hooks.ts` and `stream-hooks.ts`
- **New `runtime/subscription.ts`**: shared subscription state helpers (`resolveNanoGptSubscriptionState`, `hasNanoGptFutureGracePeriod`, `resolveNanoGptSubscriptionActive`) deduplicated from `routing.ts` and `usage.ts`
- **`provider/replay-hooks.ts`**: now imports from `markers.ts` + `inspection.ts`; removed ~35 lines of local copies
- **`provider/stream-hooks.ts`**: now imports from `markers.ts` + `inspection.ts`; removed ~43 lines of local copies
- **`runtime/routing.ts`**: now imports from `subscription.ts`; removed ~76 lines of local copies
- **`runtime/usage.ts`**: removed 62 lines of duplicate subscription helpers
- **`nanogpt-errors.ts`**: replaced local `isRecord` with import from `shared/guards.js`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 181 passed, 2 skipped (all refactor-affected tests pass)

Note: `openclaw-discovery.test.ts` and `install-preflight.test.ts` had pre-existing failures unrelated to this refactor (confirmed by testing at b8a956e before any changes were applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)