### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix environment variable exfiltration via apiKey regex

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-05-20 - Fix environment variable exfiltration via apiKey parameter
+
+**Vulnerability:** The code in `web-search/credentials.ts` validated if a string looked like an environment variable reference (e.g. `${ENV_VAR}`) using the restrictive regex `/^\$\{([A-Z][A-Z0-9_]*)\}$/`.
+
+**Learning:** This regex failed to catch secrets named with lowercase characters or leading underscores (e.g., `${_secret}` or `${my_secret}`). This allowed those strings to bypass the check and potentially leak an environment variable value if the underlying framework tried to resolve it.
+
+**Prevention:** Always use broad regexes when checking for unsafe string formats (like `/^\$\{([^}]+)\}$/` instead of `/^\$\{([A-Z][A-Z0-9_]*)\}$/`) to ensure attackers cannot bypass validation simply by changing the casing or naming pattern.

--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -308,6 +308,8 @@ describe("nanogpt web search provider", () => {
     });
 
     expect(apiKey).toBeUndefined();
+    expect(__testing.resolveNanoGptWebSearchApiKey({ apiKey: "${_secret}" })).toBeUndefined();
+    expect(__testing.resolveNanoGptWebSearchApiKey({ apiKey: "${secret_var}" })).toBeUndefined();
   });
 
   it("resolves env secret refs from the provisioned NanoGPT web_search credential path", async () => {

--- a/web-search/credentials.ts
+++ b/web-search/credentials.ts
@@ -36,7 +36,7 @@ function resolveNanoGptWebSearchApiKey(searchConfig?: Record<string, unknown>): 
 
   const rawCredentialValue = searchConfig?.apiKey;
   // If it looks like an environment variable but didn't match the safe pattern, don't pass it through
-  const isUnsafeEnvRef = typeof rawCredentialValue === "string" && /^\$\{([A-Z][A-Z0-9_]*)\}$/.test(rawCredentialValue.trim());
+  const isUnsafeEnvRef = typeof rawCredentialValue === "string" && /^\$\{([^}]+)\}$/.test(rawCredentialValue.trim());
 
   return resolveWebSearchProviderCredential({
     credentialValue:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The codebase had a vulnerability where the `isUnsafeEnvRef` regex in `web-search/credentials.ts` was overly restrictive, matching only uppercase environment variable names.
🎯 **Impact:** An attacker could craft an API key value like `"${_secret}"` or `"${my_secret}"` to bypass this validation, potentially causing the underlying system to resolve arbitrary environment variables.
🔧 **Fix:** Replaced the restrictive regex (`/^\$\{([A-Z][A-Z0-9_]*)\}$/`) with a safer and broader regex (`/^\$\{([^}]+)\}$/`) to properly block any string formatted as an environment variable reference. Added tests to verify that lowercase and underscore-prefixed environment variables are correctly blocked.
✅ **Verification:** Ran `pnpm test` and `pnpm typecheck` successfully, including the new unit tests explicitly validating that lower-case and underscored variables are caught.

---
*PR created automatically by Jules for task [17456844795767053647](https://jules.google.com/task/17456844795767053647) started by @deadronos*