### PR TITLE
🛡️ Sentinel: [security improvement] Add prompt length limit in image generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -5,3 +5,7 @@
 **Learning:** This regex failed to catch secrets named with lowercase characters or leading underscores (e.g., `${_secret}` or `${my_secret}`). This allowed those strings to bypass the check and potentially leak an environment variable value if the underlying framework tried to resolve it.
 
 **Prevention:** Always use broad regexes when checking for unsafe string formats (like `/^\$\{([^}]+)\}$/` instead of `/^\$\{([A-Z][A-Z0-9_]*)\}$/`) to ensure attackers cannot bypass validation simply by changing the casing or naming pattern.
+## 2026-04-24 - Add input length limits to image generation prompt
+**Vulnerability:** The image generation provider accepted an arbitrarily long `req.prompt` parameter, passing it directly to the provider payload. This lack of validation created a potential DoS/resource exhaustion vector.
+**Learning:** Missing length limits on arbitrary text inputs passed to external APIs can be exploited to cause large memory allocations or exceed upstream API payload limits unnecessarily.
+**Prevention:** Implement input length validation early in the request pipeline (e.g. `req.prompt.length > 4000`) to enforce a safe maximum before payload serialization.

--- a/image-generation-provider.test.ts
+++ b/image-generation-provider.test.ts
@@ -365,6 +365,21 @@ describe("nanogpt image-generation provider", () => {
     );
   });
 
+  it("throws an error when the prompt is too long", async () => {
+    mockNanoGptApiKey();
+
+    const provider = buildNanoGptImageGenerationProvider();
+
+    await expect(async () => {
+      await provider.generateImage({
+        provider: "nanogpt",
+        model: "hidream",
+        prompt: "a".repeat(4001),
+        cfg: {},
+      });
+    }).rejects.toThrow("Image prompt is too long (maximum 4000 characters).");
+  });
+
   it("falls back to default timeout when req.timeoutMs is not set", async () => {
     mockNanoGptApiKey();
 

--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -82,6 +82,11 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
         validateNanoGptImageSize(size);
       }
       const inputImages = req.inputImages ?? [];
+
+      if (req.prompt && req.prompt.length > 4000) {
+        throw new Error("Image prompt is too long (maximum 4000 characters).");
+      }
+
       const body: Record<string, unknown> = {
         model,
         prompt: req.prompt,


### PR DESCRIPTION
This PR adds a security enhancement to prevent Denial of Service (DoS) and potential resource exhaustion vulnerabilities caused by arbitrarily long prompts being sent to the `image-generation-provider.ts`. 

The fix limits the prompt length to a maximum of 4000 characters and throws an error if it is exceeded. Tests have been updated to ensure the validation operates correctly.

---
*PR created automatically by Jules for task [14246659269295306602](https://jules.google.com/task/14246659269295306602) started by @deadronos*