### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix environment variable exfiltration via apiKey parameter

### DIFF
--- a/web-search/credentials.ts
+++ b/web-search/credentials.ts
@@ -36,7 +36,8 @@ function resolveNanoGptWebSearchApiKey(searchConfig?: Record<string, unknown>): 
 
   const rawCredentialValue = searchConfig?.apiKey;
   // If it looks like an environment variable but didn't match the safe pattern, don't pass it through
-  const isUnsafeEnvRef = typeof rawCredentialValue === "string" && /^\$\{([^}]+)\}$/.test(rawCredentialValue.trim());
+  // Security fix: Use broad regex to prevent partial match bypasses for environment variable exfiltration
+  const isUnsafeEnvRef = typeof rawCredentialValue === "string" && /\$\{([^}]+)\}/.test(rawCredentialValue.trim());
 
   return resolveWebSearchProviderCredential({
     credentialValue:


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix environment variable exfiltration via apiKey parameter

**Severity:** CRITICAL
**Vulnerability:** The code in `web-search/credentials.ts` validated if a string looked like an environment variable reference using the restrictive regex `/^\$\{([^}]+)\}$/`. This regex failed to catch secrets embedded within strings (e.g., `Bearer ${SECRET}`).
**Impact:** This allowed those strings to bypass the check and potentially leak an environment variable value if the underlying framework tried to resolve it.
**Fix:** Always use broad regexes when checking for unsafe string formats (`/\$\{([^}]+)\}/` instead of `/^\$\{([^}]+)\}$/`) to ensure attackers cannot bypass validation simply by changing the casing, naming pattern, or adding prefixes/suffixes.
**Verification:** Run `pnpm test` and `pnpm lint`. Tests correctly pass.

---
*PR created automatically by Jules for task [3248546452891980054](https://jules.google.com/task/3248546452891980054) started by @deadronos*