### PR TITLE
🛡️ Sentinel: [Enhancement] Add array length limits to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The image generation provider accepted an arbitrarily long `req.prompt` parameter, passing it directly to the provider payload. This lack of validation created a potential DoS/resource exhaustion vector.
 **Learning:** Missing length limits on arbitrary text inputs passed to external APIs can be exploited to cause large memory allocations or exceed upstream API payload limits unnecessarily.
 **Prevention:** Implement input length validation early in the request pipeline (e.g. `req.prompt.length > 4000`) to enforce a safe maximum before payload serialization.
+
+## 2024-05-20 - Missing array length limits for external tool inputs
+**Vulnerability:** External inputs that accept arrays (e.g., `includeDomains`, `excludeDomains` in web-search) were missing length limits. This creates a resource exhaustion (DoS) vector if a user or agent submits an array with thousands of items.
+**Learning:** Even if individual strings inside an array are bounded by JSON schema or token limits, the array itself must have a maximum length enforced to prevent excessive iterations or huge payload sizes.
+**Prevention:** Always enforce a hard `length` limit on any user-provided array (e.g. `if (array.length > 50) throw new Error(...)`) before processing it.

--- a/web-search.ts
+++ b/web-search.ts
@@ -131,7 +131,14 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         getWebSearchLogger().info("web search request", { query });
         const count = resolveSearchCount(readNumberParam(args, "count", { integer: true }), 5);
         const includeDomains = readStringArrayParam(args, "includeDomains")?.filter(Boolean);
+        if (includeDomains && includeDomains.length > 50) {
+          throw new Error("Too many include domains (maximum 50).");
+        }
+
         const excludeDomains = readStringArrayParam(args, "excludeDomains")?.filter(Boolean);
+        if (excludeDomains && excludeDomains.length > 50) {
+          throw new Error("Too many exclude domains (maximum 50).");
+        }
 
         return await postTrustedWebToolsJson(
           {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External inputs that accept arrays (e.g., `includeDomains`, `excludeDomains` in `web-search.ts`) were missing length limits.
🎯 **Impact:** This creates a resource exhaustion (DoS) vector if a user or agent submits an array with thousands of items.
🔧 **Fix:** Enforced a maximum length of 50 on `includeDomains` and `excludeDomains` arrays.
✅ **Verification:** Verified by running `pnpm test`, `pnpm format`, and `pnpm lint`. All passed successfully.

---
*PR created automatically by Jules for task [2679199341426759901](https://jules.google.com/task/2679199341426759901) started by @deadronos*