### PR TITLE
🧪 add tests for invalid JSON handling in usage snapshot fetch

### DIFF
--- a/runtime/usage.test.ts
+++ b/runtime/usage.test.ts
@@ -82,4 +82,42 @@ describe("fetchNanoGptUsageSnapshot", () => {
       error: expect.stringContaining("HTTP 401"),
     });
   });
+
+  it("returns an error snapshot on invalid JSON", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("SyntaxError: Unexpected token");
+      },
+    });
+
+    await expect(
+      fetchNanoGptUsageSnapshot({
+        token: "test-key",
+        timeoutMs: 1_000,
+        fetchFn: fetchSpy,
+      } as never),
+    ).resolves.toMatchObject({
+      provider: "nanogpt",
+      error: "Invalid JSON",
+    });
+  });
+
+  it("returns an error snapshot on null payload", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => null,
+    });
+
+    await expect(
+      fetchNanoGptUsageSnapshot({
+        token: "test-key",
+        timeoutMs: 1_000,
+        fetchFn: fetchSpy,
+      } as never),
+    ).resolves.toMatchObject({
+      provider: "nanogpt",
+      error: "Invalid JSON",
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for invalid JSON handling in `fetchNanoGptUsageSnapshot`.
📊 **Coverage:** 
- Simulates a 200 OK response with unparseable body (throws on `json()`).
- Simulates a 200 OK response with `null` payload.
✨ **Result:** Improved reliability of usage reporting by ensuring error states are correctly detected and handled.

---
*PR created automatically by Jules for task [7246882270828866164](https://jules.google.com/task/7246882270828866164) started by @deadronos*