### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to domains arrays and truncate upstream error payloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The image generation provider accepted an arbitrarily long `req.prompt` parameter, passing it directly to the provider payload. This lack of validation created a potential DoS/resource exhaustion vector.
 **Learning:** Missing length limits on arbitrary text inputs passed to external APIs can be exploited to cause large memory allocations or exceed upstream API payload limits unnecessarily.
 **Prevention:** Implement input length validation early in the request pipeline (e.g. `req.prompt.length > 4000`) to enforce a safe maximum before payload serialization.
+## 2026-05-24 - Limit array sizes and external error strings to prevent DoS and information leak
+
+**Vulnerability:** The web search provider did not enforce a size limit on the `includeDomains` and `excludeDomains` input arrays. Additionally, the image generation provider threw the raw text of HTTP error responses from the upstream API directly to the user.
+**Learning:** Failing to enforce limits on arrays creates an Application-level DoS vector, and passing upstream HTTP error bodies blindly can lead to large allocations, unexpected payload leakage, and crashes.
+**Prevention:** Cap array inputs (e.g. `includeDomains.length > 50`) and limit external error responses to a safe length (e.g. `detail.slice(0, 200)`) before logging or throwing.

--- a/image-generation-provider.ts
+++ b/image-generation-provider.ts
@@ -143,8 +143,9 @@ export function buildNanoGptImageGenerationProvider(): ImageGenerationProvider {
             response.status === 400 &&
             /unknown model|invalid model|model/i.test(detail)
           ) {
+            const safeDetail = detail.length > 200 ? `${detail.slice(0, 200)}...` : detail;
             throw new Error(
-              `${buildUnsupportedModelGuidance(requestedModel)} NanoGPT said: ${detail}`,
+              `${buildUnsupportedModelGuidance(requestedModel)} NanoGPT said: ${safeDetail}`,
             );
           }
         }

--- a/web-search.ts
+++ b/web-search.ts
@@ -133,6 +133,13 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         const includeDomains = readStringArrayParam(args, "includeDomains")?.filter(Boolean);
         const excludeDomains = readStringArrayParam(args, "excludeDomains")?.filter(Boolean);
 
+        if (includeDomains && includeDomains.length > 50) {
+          throw new Error("Too many include domains specified (maximum 50).");
+        }
+        if (excludeDomains && excludeDomains.length > 50) {
+          throw new Error("Too many exclude domains specified (maximum 50).");
+        }
+
         return await postTrustedWebToolsJson(
           {
             url: NANOGPT_WEB_SEARCH_URL,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unbounded array inputs in `web-search.ts` (`includeDomains` and `excludeDomains`) posed a potential resource exhaustion (DoS) vector, and un-truncated upstream error responses in `image-generation-provider.ts` posed a potential information leak/payload overflow risk.
🎯 Impact: Attackers could submit gigantic arrays causing high memory consumption or excessively large request bodies. Upstream API could return gigantic error payloads causing log pollution or crashes when parsing error strings.
🔧 Fix: Added array length limits (50 items) for `includeDomains` and `excludeDomains`. Truncated upstream error payloads to 200 characters before including them in the exception string.
✅ Verification: Ensure `pnpm test` and `pnpm typecheck` still pass.

---
*PR created automatically by Jules for task [17558082489114419493](https://jules.google.com/task/17558082489114419493) started by @deadronos*