### PR TITLE
🧪 Add test for probeNanoGptSubscription failing with non-OK status

### DIFF
--- a/runtime/routing.test.ts
+++ b/runtime/routing.test.ts
@@ -10,6 +10,7 @@ import {
   buildNanoGptRequestHeaders,
   resolveCatalogBaseUrl,
   resolveCatalogSource,
+  probeNanoGptSubscription,
   resolveNanoGptRoutingMode,
   resolveRequestBaseUrl,
 } from "./routing.js";
@@ -17,6 +18,20 @@ import {
 afterEach(() => {
   resetNanoGptRuntimeState();
   vi.unstubAllGlobals();
+});
+
+describe("probeNanoGptSubscription", () => {
+  it("throws when the subscription probe fails with a non-OK status", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(probeNanoGptSubscription("test-key")).rejects.toThrow(
+      "NanoGPT subscription probe failed with HTTP 500",
+    );
+  });
 });
 
 describe("resolveNanoGptRoutingMode", () => {


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed: untestable throw when subscription probe fails with non-OK status.
* 📊 **Coverage:** Added a test case in `runtime/routing.test.ts` that mocks `fetch` returning a non-OK status and asserts the expected error message.
* ✨ **Result:** Improved test coverage by verifying the behavior of `probeNanoGptSubscription` when the probe fails.

---
*PR created automatically by Jules for task [13708477341581747964](https://jules.google.com/task/13708477341581747964) started by @deadronos*