### PR TITLE
🧪 test: add coverage for provider configuration extraction

### DIFF
--- a/provider-catalog.test.ts
+++ b/provider-catalog.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildNanoGptProvider } from "./catalog/build-provider.js";
-import { NANOGPT_FALLBACK_MODELS } from "./models.js";
+import { NANOGPT_FALLBACK_MODELS, NANOGPT_PROVIDER_ID } from "./models.js";
 import { resetNanoGptRuntimeState } from "./runtime.js";
+import { resolveNanoGptPluginConfigFromProviderCatalogContext } from "./provider-catalog.js";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
 
 afterEach(() => {
   resetNanoGptRuntimeState();
@@ -412,5 +414,62 @@ describe("buildNanoGptProvider", () => {
     expect(provider.baseUrl).toBe("https://nano-gpt.com/api/v1");
     expect(provider.models.map((model) => model.id)).toEqual(NANOGPT_FALLBACK_MODELS.map((model) => model.id));
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+
+describe("resolveNanoGptPluginConfigFromProviderCatalogContext", () => {
+  it("extracts the configuration when correctly structured", () => {
+    const ctx = {
+      config: {
+        plugins: {
+          entries: {
+            [NANOGPT_PROVIDER_ID]: {
+              config: { routingMode: "auto" },
+            },
+          },
+        },
+      },
+    } as unknown as ProviderCatalogContext;
+
+    expect(resolveNanoGptPluginConfigFromProviderCatalogContext(ctx)).toEqual({ routingMode: "auto" });
+  });
+
+  it("returns undefined when plugins is undefined", () => {
+    const ctx = { config: {} } as unknown as ProviderCatalogContext;
+    expect(resolveNanoGptPluginConfigFromProviderCatalogContext(ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when entries is undefined", () => {
+    const ctx = { config: { plugins: {} } } as unknown as ProviderCatalogContext;
+    expect(resolveNanoGptPluginConfigFromProviderCatalogContext(ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when the specific provider ID is missing", () => {
+    const ctx = {
+      config: {
+        plugins: {
+          entries: {
+            "other-provider": {
+              config: { foo: "bar" },
+            },
+          },
+        },
+      },
+    } as unknown as ProviderCatalogContext;
+    expect(resolveNanoGptPluginConfigFromProviderCatalogContext(ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when the specific provider ID has no config", () => {
+    const ctx = {
+      config: {
+        plugins: {
+          entries: {
+            [NANOGPT_PROVIDER_ID]: {},
+          },
+        },
+      },
+    } as unknown as ProviderCatalogContext;
+    expect(resolveNanoGptPluginConfigFromProviderCatalogContext(ctx)).toBeUndefined();
   });
 });


### PR DESCRIPTION
🎯 **What:** This PR addresses the testing gap for the `resolveNanoGptPluginConfigFromProviderCatalogContext` function in `provider-catalog.ts`, which extracts the NanoGPT plugin configuration from the provider catalog context but was previously untested.

📊 **Coverage:** The new tests cover:
- Happy path: Correctly extracting the `config` when `NANOGPT_PROVIDER_ID` exists in the context entries.
- Edge case: `ctx.config.plugins` is undefined.
- Edge case: `ctx.config.plugins.entries` is undefined.
- Edge case: The specific `NANOGPT_PROVIDER_ID` is missing from the entries.
- Edge case: The specific `NANOGPT_PROVIDER_ID` is present but has no `config`.

✨ **Result:** Increased test coverage and confidence in the provider catalog configuration resolution logic by ensuring it correctly and safely handles both expected and malformed configurations.

---
*PR created automatically by Jules for task [8913413900489580743](https://jules.google.com/task/8913413900489580743) started by @deadronos*