### PR TITLE
🧪 [testing improvement] Add test for failed stream creation in nanogpt logger

### DIFF
--- a/provider/nanogpt-logger.test.ts
+++ b/provider/nanogpt-logger.test.ts
@@ -55,4 +55,31 @@ describe("nanogpt logger", () => {
     vi.doUnmock("node:fs");
     vi.resetModules();
   });
+
+  it("falls back to a no-op logger when the log file cannot be created", async () => {
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        createWriteStream: vi.fn(() => {
+          throw new Error("readonly file");
+        }),
+      };
+    });
+
+    const { createNanoGptLoggerSync: createLoggerWithFailingFs } = await import(
+      "./nanogpt-logger.js"
+    );
+    const log = createLoggerWithFailingFs("readonly-file");
+
+    expect(() => {
+      log.info("test-info");
+      log.warn("test-warn");
+      log.error("test-error");
+    }).not.toThrow();
+
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses an untested error handling path in `provider/nanogpt-logger.ts` where `createWriteStream` might throw an error when attempting to open a log file (e.g. due to permissions or a read-only filesystem). 

📊 **Coverage:** What scenarios are now tested
Added a new test case: `"falls back to a no-op logger when the log file cannot be created"`
This test uses `vi.doMock("node:fs")` to force `createWriteStream` to throw, while leaving directory creation (`mkdirSync`) functional. It verifies that calling `.info()`, `.warn()`, and `.error()` on the resulting logger instance does not throw an exception.

✨ **Result:** The improvement in test coverage
The targeted try/catch block is now fully covered by tests. Statement coverage for `provider/nanogpt-logger.ts` improved from 68.96% to 70.68%, and the missing line 41 is now properly tested. All tests pass with no regressions introduced.

---
*PR created automatically by Jules for task [12010660031772892069](https://jules.google.com/task/12010660031772892069) started by @deadronos*