### PR TITLE
🧪 Add test for error extraction JSON parsing fallback

### DIFF
--- a/nanogpt-errors.test.ts
+++ b/nanogpt-errors.test.ts
@@ -161,6 +161,14 @@ describe("inspectNanoGptErrorSurface", () => {
       }),
     });
   });
+
+  it("gracefully falls back to null when JSON parsing fails on HTML-like payloads", () => {
+    expect(
+      inspectNanoGptErrorSurface(
+        "<html><body>Server Error { statusCode: 500 }</body></html>"
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("formatNanoGptErrorSurfaceDetails", () => {


### PR DESCRIPTION
🎯 **What:** Adds test coverage for the fallback block in `extractJsonRecord` that swallows syntax errors when parsing invalid JSON payload candidates.
📊 **Coverage:** The `inspectNanoGptErrorSurface` test suite now covers cases where string parsing returns HTML/text disguised with curly braces.
✨ **Result:** Ensures the system correctly bails out returning null rather than crashing on unexpected HTML payloads.

---
*PR created automatically by Jules for task [14094997369251376526](https://jules.google.com/task/14094997369251376526) started by @deadronos*