### PR TITLE
🧪 Test provider pricing fetch failure cache handling

### DIFF
--- a/runtime/provider-pricing.test.ts
+++ b/runtime/provider-pricing.test.ts
@@ -97,6 +97,38 @@ describe("fetchNanoGptSelectedProviderPricing", () => {
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("caches fetch failures using a very short TTL", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const params = {
+      apiKey: "test-key",
+      modelId: "test-model",
+      provider: "valid-provider",
+    };
+
+    // First call: should trigger fetch and return null
+    const firstResult = await fetchNanoGptSelectedProviderPricing(params);
+    expect(firstResult).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second call: should hit the very short failure cache, fetch not called again
+    const secondResult = await fetchNanoGptSelectedProviderPricing(params);
+    expect(secondResult).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Advance time past VERY_SHORT_FAILURE_CACHE_TTL_MS (5000ms)
+    vi.advanceTimersByTime(5001);
+
+    // Third call: cache expired, should trigger fetch again
+    const thirdResult = await fetchNanoGptSelectedProviderPricing(params);
+    expect(thirdResult).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
 });
 
 describe("resetNanoGptRuntimeState", () => {


### PR DESCRIPTION
🎯 **What:** Added a test case in `runtime/provider-pricing.test.ts` to cover the previously untested cache handling path when the pricing API fetch fails and falls into the `catch` block in `runtime/provider-pricing.ts`.
📊 **Coverage:** The test validates the "first fetch fails", "second fetch within very short TTL hits cache", and "third fetch past TTL triggers another fetch" scenarios.
✨ **Result:** Improved test coverage and reliability for provider pricing fetch failures, ensuring that subsequent requests within the very short cache TTL do not trigger redundant and potentially slow network requests.

---
*PR created automatically by Jules for task [3155985607881204654](https://jules.google.com/task/3155985607881204654) started by @deadronos*