### PR TITLE
Compile TypeScript to JavaScript and update package version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deadronos/nanogpt-provider-openclaw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenClaw NanoGPT provider plugin",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./dist/index.js"
+      "./index.js"
     ],
     "providers": [
       "nanogpt"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "files": [
+    "dist/",
     "index.ts",
     "api.ts",
     "models.ts",
@@ -83,7 +84,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "build": "npm run typecheck && node ./scripts/stage-package-dir.mjs",
+    "compile": "tsc --noEmit && node ./scripts/compile.mjs",
+    "build": "npm run compile && node ./scripts/stage-package-dir.mjs",
     "build:tgz": "npm run build && npm pack ./dist/package --pack-destination ./dist",
     "format": "oxfmt --write",
     "format:check": "oxfmt --check --threads=1",
@@ -98,6 +100,7 @@
   "devDependencies": {
     "@types/node": "^24.6.0",
     "@vitest/coverage-v8": "^4.1.4",
+    "esbuild": "^0.25.0",
     "openclaw": "2026.4.22",
     "oxfmt": "0.46.0",
     "oxlint": "^1.61.0",
@@ -138,7 +141,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "providers": [
       "nanogpt"

--- a/scripts/compile.mjs
+++ b/scripts/compile.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import * as esbuild from "esbuild";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const outDir = path.join(repoRoot, "dist");
+
+// Clean dist directory before compilation
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+
+// Collect all .ts entry points from the files list
+const entryPoints = new Set();
+for (const file of packageJson.files) {
+  if (file.endsWith(".ts") && !file.includes("/")) {
+    entryPoints.add(path.join(repoRoot, file));
+  }
+  // Also check subdirectory .ts files
+  if (file.includes(".ts")) {
+    const fullPath = path.join(repoRoot, file);
+    if (fs.existsSync(fullPath) && !entryPoints.has(fullPath)) {
+      // Only add if it's a direct entry point (not a依赖)
+    }
+  }
+}
+
+// Actually, let's just compile all .ts files in the root and subdirectories
+// that are part of the package surface
+function findTsEntries(dir, base = "") {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === ".git") continue;
+    const relPath = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      findTsEntries(path.join(dir, entry.name), relPath);
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      entryPoints.add(path.join(dir, entry.name));
+    }
+  }
+}
+
+findTsEntries(repoRoot);
+
+const entryArray = [...entryPoints].filter((p) => !p.endsWith(".test.ts"));
+
+await esbuild.build({
+  entryPoints: entryArray,
+  outdir: outDir,
+  platform: "node",
+  target: "node18",
+  format: "esm",
+  bundle: false,
+  splitting: false,
+  sourcemap: false,
+  minify: false,
+});
+
+console.log(`Compiled ${entryArray.length} entry points to ${outDir}`);

--- a/scripts/stage-package-dir.mjs
+++ b/scripts/stage-package-dir.mjs
@@ -23,7 +23,7 @@ export function resolvePackageSurfaceEntries(manifest) {
     ? manifest.files.map(normalizeSurfaceEntry).filter(Boolean)
     : [];
 
-  return ["package.json", ...explicitEntries];
+  return ["package.json", ...explicitEntries.filter((e) => !e.startsWith("dist/"))];
 }
 
 function copySurfaceEntry(sourcePath, targetPath) {
@@ -36,6 +36,35 @@ function copySurfaceEntry(sourcePath, targetPath) {
   }
 
   fs.copyFileSync(sourcePath, targetPath);
+}
+
+function mergeCompiledOutput(repoRoot, outputDir) {
+  const compileDir = path.join(repoRoot, "dist");
+  if (!fs.existsSync(compileDir)) {
+    return;
+  }
+  // Copy compiled JS files over their .ts counterparts in the staged package
+  // to make compiled JS take precedence
+  for (const entry of getAllFiles(compileDir)) {
+    const src = path.join(compileDir, entry);
+    const dst = path.join(outputDir, entry);
+    if (fs.statSync(src).isDirectory()) continue;
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.copyFileSync(src, dst);
+  }
+}
+
+function getAllFiles(dir, base = "") {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const relPath = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...getAllFiles(path.join(dir, entry.name), relPath));
+    } else {
+      files.push(relPath);
+    }
+  }
+  return files;
 }
 
 export function stagePackageDir(params = {}) {
@@ -62,6 +91,8 @@ export function stagePackageDir(params = {}) {
     const targetPath = path.join(outputDir, entry);
     copySurfaceEntry(sourcePath, targetPath);
   }
+
+  mergeCompiledOutput(repoRoot, outputDir);
 
   return outputDir;
 }


### PR DESCRIPTION
Add TypeScript compilation to the build process using esbuild, ensuring compiled JavaScript is included in the plugin package. Update the OpenClaw extension path and version in package.json.