### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Sensitive Data Leak in Logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-20 - [Redact Sensitive Data In Log Meta Output]
+**Vulnerability:** The logger `provider/nanogpt-logger.ts` was serializing the raw `meta` object using `JSON.stringify(meta)` without redacting sensitive information like `apiKey`, `secret`, `token`, `password`, and `authorization` keys.
+**Learning:** Raw logger implementations should always use a JSON replacer to intercept object key serialization in order to filter/redact sensitive metadata (e.g. passwords, API keys) which may inadvertently be passed into logs, thus polluting logs with secrets.
+**Prevention:** Implement a replacer function for `JSON.stringify` that checks keys via regex and redacts sensitive data with `[REDACTED]`.

--- a/provider/nanogpt-logger.test.ts
+++ b/provider/nanogpt-logger.test.ts
@@ -29,6 +29,34 @@ describe("nanogpt logger", () => {
     expect(contents).toContain('"key":"value"');
   });
 
+  it("redacts sensitive keys from meta", async () => {
+    const log = createNanoGptLoggerSync("test-redact");
+    log.info("test-redact-info", {
+      normalKey: "visible",
+      apiKey: "secret-api-key",
+      nanoGptApiKey: "secret-nanogpt-key",
+      nested: { token: "secret-token", password: "secret-password" },
+      authorization: "secret-auth",
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(existsSync(LOG_PATH)).toBe(true);
+    const contents = readFileSync(LOG_PATH, "utf8");
+    expect(contents).toContain("test-redact-info");
+    expect(contents).toContain('"normalKey":"visible"');
+    expect(contents).toContain('"apiKey":"[REDACTED]"');
+    expect(contents).toContain('"nanoGptApiKey":"[REDACTED]"');
+    expect(contents).toContain('"token":"[REDACTED]"');
+    expect(contents).toContain('"password":"[REDACTED]"');
+    expect(contents).toContain('"authorization":"[REDACTED]"');
+    expect(contents).not.toContain("secret-api-key");
+    expect(contents).not.toContain("secret-nanogpt-key");
+    expect(contents).not.toContain("secret-token");
+    expect(contents).not.toContain("secret-password");
+    expect(contents).not.toContain("secret-auth");
+  });
+
   it("falls back to a no-op logger when the log directory cannot be created", async () => {
     vi.resetModules();
     vi.doMock("node:fs", async () => {

--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -62,9 +62,18 @@ function formatTimestamp(): string {
   return new Date().toISOString();
 }
 
+const SENSITIVE_KEYS = /apikey|nanogptapikey|token|password|secret|authorization|credential|cookie/i;
+
+function redactReplacer(key: string, value: unknown): unknown {
+  if (SENSITIVE_KEYS.test(key)) {
+    return "[REDACTED]";
+  }
+  return value;
+}
+
 function formatLogLine(level: NanoGptLogLevel, module: string, message: string, meta?: Record<string, unknown>): string {
   const timestamp = formatTimestamp();
-  const metaStr = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : "";
+  const metaStr = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta, redactReplacer)}` : "";
   return `${timestamp} [${level}] [${module}] ${message}${metaStr}\n`;
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Sensitive Data Leak in Logs

🚨 Severity: MEDIUM
💡 Vulnerability: The logger `provider/nanogpt-logger.ts` was serializing the raw `meta` object using `JSON.stringify(meta)` without redacting sensitive information like `apiKey`, `secret`, `token`, `password`, and `authorization` keys. This could lead to sensitive API keys and credentials polluting log files.
🎯 Impact: If the log files are accessed by unauthorized users, or ingested into a centralized logging system, sensitive API keys and other secrets could be exposed.
🔧 Fix: Implemented a `redactReplacer` function for `JSON.stringify` that checks keys via regex (case-insensitive) and redacts sensitive data with `[REDACTED]`.
✅ Verification: Added a test case in `provider/nanogpt-logger.test.ts` to ensure that sensitive keys are replaced with `[REDACTED]` when the logger is called. Run `pnpm test` to verify.

---
*PR created automatically by Jules for task [6020851486240938745](https://jules.google.com/task/6020851486240938745) started by @deadronos*