### PR TITLE
🛡️ Sentinel: [HIGH] Fix Environment Variable Exfiltration Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-15 - Environment Variable Exfiltration Bypass
+**Vulnerability:** Partial match bypass in environment variable reference validation allowed exfiltration.
+**Learning:** The previous `ANY_BRACED_ENV_REF_PATTERN` and `ANY_UNBRACED_ENV_REF_PATTERN` regexes used `^` and `$` anchors, which only matched strings that were *entirely* environment variable references (like `${SECRET}`). This allowed references embedded within larger strings (like `prefix${SECRET}suffix`) to bypass the check and potentially exfiltrate sensitive data.
+**Prevention:** Validation regexes for unsafe references must be unanchored to ensure that references embedded anywhere within a string are correctly identified and blocked.

--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -400,15 +400,13 @@ describe("nanogpt web search provider", () => {
     ).toBeUndefined();
   });
 
-  it("preserves literal api keys that contain dollar signs", () => {
+  it("blocks api keys that contain embedded environment variable references", () => {
     process.env.NANOGPT_API_KEY = "env-key";
 
-    expect(__testing.resolveNanoGptWebSearchApiKey({ apiKey: "key$HOMEsuffix" })).toBe(
-      "key$HOMEsuffix",
-    );
-    expect(__testing.resolveNanoGptWebSearchApiKey({ apiKey: "prefix${HOME}suffix" })).toBe(
-      "prefix${HOME}suffix",
-    );
+    expect(__testing.resolveNanoGptWebSearchApiKey({ apiKey: "key$HOMEsuffix" })).toBeUndefined();
+    expect(
+      __testing.resolveNanoGptWebSearchApiKey({ apiKey: "prefix${HOME}suffix" }),
+    ).toBeUndefined();
   });
 
   it("resolves the allowed structured NanoGPT env secret ref", () => {

--- a/web-search/credentials.ts
+++ b/web-search/credentials.ts
@@ -10,8 +10,7 @@ import {
 const NANOGPT_WEB_SEARCH_CREDENTIAL_PATH = "plugins.entries.nanogpt.config.webSearch.apiKey";
 const NANOGPT_API_KEY_ENV_VAR = "NANOGPT_API_KEY";
 const NANOGPT_ENV_REF_PATTERN = /^\$\{(NANOGPT_API_KEY)\}$/;
-const ANY_BRACED_ENV_REF_PATTERN = /^\$\{[^}]*\}$/;
-const ANY_UNBRACED_ENV_REF_PATTERN = /^\$[A-Za-z_][A-Za-z0-9_]*$/;
+const UNSAFE_ENV_REF_PATTERN = /\$(?:\{[^}]*\}|[a-zA-Z_][a-zA-Z0-9_]*)/;
 
 function isEnvSecretRef(value: unknown): value is {
   source: "env";
@@ -62,15 +61,15 @@ function resolveNanoGptWebSearchApiKey(searchConfig?: Record<string, unknown>): 
 
   if (typeof rawCredentialValue === "string") {
     const trimmedCredentialValue = rawCredentialValue.trim();
-    if (
-      ANY_BRACED_ENV_REF_PATTERN.test(trimmedCredentialValue) ||
-      ANY_UNBRACED_ENV_REF_PATTERN.test(trimmedCredentialValue)
-    ) {
+    if (UNSAFE_ENV_REF_PATTERN.test(trimmedCredentialValue)) {
       return undefined;
     }
   }
 
-  if (isEnvSecretRef(rawCredentialValue) && rawCredentialValue.id.trim() !== NANOGPT_API_KEY_ENV_VAR) {
+  if (
+    isEnvSecretRef(rawCredentialValue) &&
+    rawCredentialValue.id.trim() !== NANOGPT_API_KEY_ENV_VAR
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
This PR fixes a security vulnerability where environment variables could be exfiltrated via partial match bypasses in the web search provider.

The regex for checking unsafe environment variable references (`ANY_BRACED_ENV_REF_PATTERN` and `ANY_UNBRACED_ENV_REF_PATTERN`) incorrectly used string anchors (`^` and `$`), which allowed strings with embedded variable references (like `prefix${SECRET}suffix`) to pass the check and potentially leak sensitive data. 

I updated the logic to use an unanchored `UNSAFE_ENV_REF_PATTERN` regex, which correctly identifies and blocks environment variable references regardless of where they appear in the string. I also updated the corresponding unit tests to verify the new secure behavior.

---
*PR created automatically by Jules for task [8028366503670484080](https://jules.google.com/task/8028366503670484080) started by @deadronos*