### PR TITLE
docs: add TweetClaw companion workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ For now, the plugin keeps both manifest paths in sync: the legacy
 Newer OpenClaw builds prefer the setup descriptor path, while older installs
 still pick up the compatibility metadata.
 
+## Pair with TweetClaw X/Twitter tools
+
+NanoGPT handles model, `web_search`, and image provider traffic. If the same
+OpenClaw agent also needs X/Twitter automation, install TweetClaw as a separate
+tool plugin:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+Keep the NanoGPT API key and Xquik API key in separate environment variables.
+TweetClaw registers `explore` for free endpoint discovery and optional
+`tweetclaw` for live API calls. Use it when a NanoGPT-routed agent needs to
+scrape tweets, search tweet replies, post tweets or replies, export followers,
+look up users, monitor tweets, deliver webhooks, handle media, send direct
+messages, or run giveaway draws from OpenClaw. Review OpenClaw approval prompts
+before approving write actions such as posts, replies, follows, DMs, monitor
+changes, webhooks, or profile updates.
+
 ## Text provider configuration
 
 The plugin config controls NanoGPT text-model discovery and transport behavior:


### PR DESCRIPTION
## Summary
- Document TweetClaw as an optional companion tool plugin for NanoGPT-routed OpenClaw agents.
- Add install, credential, and tool allowlist commands.
- Keep NanoGPT and Xquik credentials separate while listing concrete X/Twitter workflows.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm pack --dry-run --json`
- `git diff --check`
- Link checks: target repo and issues 200, TweetClaw GitHub 200, ClawHub listing 200, xquik.com 200, dashboard.xquik.com 200, npm registry metadata for `@xquik/tweetclaw` OK