### PR TITLE
🔒 [security fix] Redact sensitive metadata in NanoGPT logger

### DIFF
--- a/provider/nanogpt-logger.test.ts
+++ b/provider/nanogpt-logger.test.ts
@@ -29,6 +29,31 @@ describe("nanogpt logger", () => {
     expect(contents).toContain('"key":"value"');
   });
 
+  it("redacts sensitive keys in the metadata", async () => {
+    const log = createNanoGptLoggerSync("test-redaction");
+    log.info("sensitive-info", {
+      apiKey: "secret-key",
+      nested: {
+        token: "secret-token",
+        other: "safe",
+      },
+      safe: "data",
+    });
+
+    // Stream buffers — give it a moment to flush
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(existsSync(LOG_PATH)).toBe(true);
+    const contents = readFileSync(LOG_PATH, "utf8");
+    expect(contents).toContain("[info] [test-redaction] sensitive-info");
+    expect(contents).toContain('"apiKey":"[REDACTED]"');
+    expect(contents).toContain('"token":"[REDACTED]"');
+    expect(contents).toContain('"other":"safe"');
+    expect(contents).toContain('"safe":"data"');
+    expect(contents).not.toContain("secret-key");
+    expect(contents).not.toContain("secret-token");
+  });
+
   it("falls back to a no-op logger when the log directory cannot be created", async () => {
     vi.resetModules();
     vi.doMock("node:fs", async () => {

--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -58,13 +58,45 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
+const SENSITIVE_KEYS = new Set([
+  "apikey",
+  "nanogptapikey",
+  "token",
+  "password",
+  "secret",
+  "authorization",
+  "credential",
+  "cookie",
+]);
+
+function redact(val: unknown): unknown {
+  if (val === null || typeof val !== "object") {
+    return val;
+  }
+
+  if (Array.isArray(val)) {
+    return val.map(redact);
+  }
+
+  const record = val as Record<string, unknown>;
+  const redacted: Record<string, unknown> = {};
+  for (const key in record) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      redacted[key] = "[REDACTED]";
+    } else {
+      redacted[key] = redact(record[key]);
+    }
+  }
+  return redacted;
+}
+
 function formatTimestamp(): string {
   return new Date().toISOString();
 }
 
 function formatLogLine(level: NanoGptLogLevel, module: string, message: string, meta?: Record<string, unknown>): string {
   const timestamp = formatTimestamp();
-  const metaStr = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : "";
+  const metaStr = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(redact(meta))}` : "";
   return `${timestamp} [${level}] [${module}] ${message}${metaStr}\n`;
 }
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Sensitive metadata (like API keys, tokens, and passwords) was being logged in plain text in the `nanogpt.log` file when passed as part of the `meta` object to the logger.

### ⚠️ Risk: The potential impact if left unfixed
Exposure of sensitive credentials in log files could lead to unauthorized access to the NanoGPT API or other services if the log files are accessed by unauthorized users or systems.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix introduces a `redact` utility function in `provider/nanogpt-logger.ts` that recursively traverses the metadata object and replaces values of sensitive keys with `[REDACTED]`. This function is now called on the metadata before it is stringified and written to the log file. Case-insensitive matching is used to ensure keys like `apikey` and `apiKey` are both caught.

---
*PR created automatically by Jules for task [9738614407221287336](https://jules.google.com/task/9738614407221287336) started by @deadronos*