### PR TITLE
🛡️ Sentinel: [HIGH] Fix URL normalization differential

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Partial match bypass in environment variable reference validation allowed exfiltration.
 **Learning:** The previous `ANY_BRACED_ENV_REF_PATTERN` and `ANY_UNBRACED_ENV_REF_PATTERN` regexes used `^` and `$` anchors, which only matched strings that were *entirely* environment variable references (like `${SECRET}`). This allowed references embedded within larger strings (like `prefix${SECRET}suffix`) to bypass the check and potentially exfiltrate sensitive data.
 **Prevention:** Validation regexes for unsafe references must be unanchored to ensure that references embedded anywhere within a string are correctly identified and blocked.
+## 2026-05-18 - SSRF/Parser Differential via URL Validation
+**Vulnerability:** The web search results normalizer (`web-search/results.ts`) validated URLs using the `URL` constructor to ensure they used `http:` or `https:`, but returned the *raw* user-supplied string rather than the parsed URL string. This allowed URL parser differentials where the string passed validation but downstream consumers interpreted it as a different, potentially malicious URI.
+**Learning:** Checking a parsed URL is not enough if you continue to use the raw, un-normalized string. You must use the sanitized, serialized output of the parser (`parsedUrl.href`) to ensure the validation logic accurately reflects what the downstream consumer will process.
+**Prevention:** Always extract and export the canonicalized properties (`parsedUrl.href`) from the parsed URL object rather than returning the raw input string.

--- a/web-search/results.ts
+++ b/web-search/results.ts
@@ -20,8 +20,9 @@ function normalizeNanoGptWebSearchResult(
     return null;
   }
 
+  let parsedUrl: URL;
   try {
-    const parsedUrl = new URL(url);
+    parsedUrl = new URL(url);
     if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
       return null;
     }
@@ -39,9 +40,9 @@ function normalizeNanoGptWebSearchResult(
 
   return {
     title: title ? wrapWebContent(title, "web_search") : "",
-    url,
+    url: parsedUrl.href,
     snippet: rawSnippet ? wrapWebContent(rawSnippet, "web_search") : "",
-    siteName: resolveSiteName(url) || undefined,
+    siteName: resolveSiteName(parsedUrl.href) || undefined,
   };
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF / URL Parser Differential. URL validation logic parsed the string with `URL` but returned the raw input, allowing potential bypasses if parsed differently by a downstream tool.
🎯 Impact: An attacker could potentially bypass the `http:` / `https:` strict protocol validation using tricky URL encoding schemes.
🔧 Fix: Updated `normalizeNanoGptWebSearchResult` in `web-search/results.ts` to output `parsedUrl.href` instead of the raw `url`.
✅ Verification: `pnpm test web-search.test.ts` passes successfully.

---
*PR created automatically by Jules for task [12185943696941357294](https://jules.google.com/task/12185943696941357294) started by @deadronos*