### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance logger secret redaction using regex matching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The web search results normalizer (`web-search/results.ts`) validated URLs using the `URL` constructor to ensure they used `http:` or `https:`, but returned the *raw* user-supplied string rather than the parsed URL string. This allowed URL parser differentials where the string passed validation but downstream consumers interpreted it as a different, potentially malicious URI.
 **Learning:** Checking a parsed URL is not enough if you continue to use the raw, un-normalized string. You must use the sanitized, serialized output of the parser (`parsedUrl.href`) to ensure the validation logic accurately reflects what the downstream consumer will process.
 **Prevention:** Always extract and export the canonicalized properties (`parsedUrl.href`) from the parsed URL object rather than returning the raw input string.
+## 2026-06-06 - [Redact Sensitive Data Using Pattern Matching]
+**Vulnerability:** The logger `provider/nanogpt-logger.ts` used an exact-match `Set` (`SENSITIVE_KEYS`) to redact sensitive data from log metadata. This would fail to redact composite keys or differently-cased keys (e.g. `jwtToken`, `my_secret`, `api_key`) that were not explicitly in the set.
+**Learning:** Security redaction mechanisms should use case-insensitive substring matching (regular expressions) instead of exact matching to ensure robustness against various key naming conventions.
+**Prevention:** Replace strict `Set.has()` checks with a regex test (e.g. `/apikey|token|password.../i.test(key)`) in logger replacer functions.

--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -21,7 +21,10 @@ const NOOP_LOGGER: NanoGptLogger = {
 let _stream: ReturnType<typeof createWriteStream> | null = null;
 let _streamPromise: Promise<void> | null = null;
 
-function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; ready: Promise<void> } | null {
+function getOrCreateStream(): {
+  stream: ReturnType<typeof createWriteStream>;
+  ready: Promise<void>;
+} | null {
   if (_stream) {
     return { stream: _stream, ready: _streamPromise ?? Promise.resolve() };
   }
@@ -58,19 +61,10 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
-const SENSITIVE_KEYS = new Set([
-  "apikey",
-  "nanogptapikey",
-  "token",
-  "password",
-  "secret",
-  "authorization",
-  "credential",
-  "cookie",
-]);
+const SENSITIVE_KEYS_PATTERN = /apikey|token|password|secret|authorization|credential|cookie/i;
 
 function redactReplacer(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+  if (SENSITIVE_KEYS_PATTERN.test(key)) {
     return "[REDACTED]";
   }
   return value;
@@ -80,7 +74,12 @@ function formatTimestamp(): string {
   return new Date().toISOString();
 }
 
-function formatLogLine(level: NanoGptLogLevel, module: string, message: string, meta?: Record<string, unknown>): string {
+function formatLogLine(
+  level: NanoGptLogLevel,
+  module: string,
+  message: string,
+  meta?: Record<string, unknown>,
+): string {
   const timestamp = formatTimestamp();
   let metaStr = "";
   if (meta && Object.keys(meta).length > 0) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The logger `provider/nanogpt-logger.ts` used an exact-match `Set` to redact sensitive metadata keys. This could lead to credential leakage if composite or differently-cased keys (e.g., `jwtToken`, `db_password`) were logged.
🎯 Impact: Sensitive credentials could be written to plain-text logs, risking unauthorized access.
🔧 Fix: Replaced the strict `Set.has()` check with a case-insensitive regular expression that matches any key containing sensitive substrings (like `apikey`, `token`, `password`).
✅ Verification: Ran `pnpm test` and `pnpm lint` to ensure no regressions. Updated `sentinel.md` journal.

---
*PR created automatically by Jules for task [1691587255586590577](https://jules.google.com/task/1691587255586590577) started by @deadronos*