### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Log Redaction Substring Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The web search results normalizer (`web-search/results.ts`) validated URLs using the `URL` constructor to ensure they used `http:` or `https:`, but returned the *raw* user-supplied string rather than the parsed URL string. This allowed URL parser differentials where the string passed validation but downstream consumers interpreted it as a different, potentially malicious URI.
 **Learning:** Checking a parsed URL is not enough if you continue to use the raw, un-normalized string. You must use the sanitized, serialized output of the parser (`parsedUrl.href`) to ensure the validation logic accurately reflects what the downstream consumer will process.
 **Prevention:** Always extract and export the canonicalized properties (`parsedUrl.href`) from the parsed URL object rather than returning the raw input string.
+## 2026-05-20 - [Redact Substring Matches In Logger]
+**Vulnerability:** The logger `provider/nanogpt-logger.ts` was using an exact match (`Set.has()`) to redact sensitive keys. This allowed keys that contained sensitive terms as substrings (e.g. `providerApiKey`, `mySecretKey`) to bypass redaction and leak credentials into logs.
+**Learning:** Exact matching for log redaction is insufficient because developers often use camelCase or snake_case composite key names that embed sensitive terms.
+**Prevention:** Implement a case-insensitive regex for the replacer function to ensure substring matches containing sensitive terms are correctly redacted.

--- a/provider/nanogpt-logger.test.ts
+++ b/provider/nanogpt-logger.test.ts
@@ -57,6 +57,34 @@ describe("nanogpt logger", () => {
     expect(contents).not.toContain("secret-auth");
   });
 
+  it("redacts keys containing sensitive substrings from meta", async () => {
+    const log = createNanoGptLoggerSync("test-redact-substrings");
+    log.info("test-redact-substrings-info", {
+      normalKey: "visible",
+      providerApiKey: "secret-api-key",
+      mySecretKey: "secret-nanogpt-key",
+      nested: { xTokenY: "secret-token", adminPasswordHash: "secret-password" },
+      authorizationHeader: "secret-auth",
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(existsSync(LOG_PATH)).toBe(true);
+    const contents = readFileSync(LOG_PATH, "utf8");
+    expect(contents).toContain("test-redact-substrings-info");
+    expect(contents).toContain('"normalKey":"visible"');
+    expect(contents).toContain('"providerApiKey":"[REDACTED]"');
+    expect(contents).toContain('"mySecretKey":"[REDACTED]"');
+    expect(contents).toContain('"xTokenY":"[REDACTED]"');
+    expect(contents).toContain('"adminPasswordHash":"[REDACTED]"');
+    expect(contents).toContain('"authorizationHeader":"[REDACTED]"');
+    expect(contents).not.toContain("secret-api-key");
+    expect(contents).not.toContain("secret-nanogpt-key");
+    expect(contents).not.toContain("secret-token");
+    expect(contents).not.toContain("secret-password");
+    expect(contents).not.toContain("secret-auth");
+  });
+
   it("handles circular references in metadata gracefully without throwing and writes the message", async () => {
     const log = createNanoGptLoggerSync("test-circular");
     const circularObj: any = { key: "value" };

--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -58,19 +58,10 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
-const SENSITIVE_KEYS = new Set([
-  "apikey",
-  "nanogptapikey",
-  "token",
-  "password",
-  "secret",
-  "authorization",
-  "credential",
-  "cookie",
-]);
+const SENSITIVE_KEY_PATTERN = /apikey|token|password|secret|authorization|credential|cookie/i;
 
 function redactReplacer(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+  if (SENSITIVE_KEY_PATTERN.test(key)) {
     return "[REDACTED]";
   }
   return value;


### PR DESCRIPTION
Replaces exact match log redaction with case-insensitive regex to catch substring matches of sensitive terms.

---
*PR created automatically by Jules for task [18418579768331331042](https://jules.google.com/task/18418579768331331042) started by @deadronos*