### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix incomplete log redaction via exact match

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The web search results normalizer (`web-search/results.ts`) validated URLs using the `URL` constructor to ensure they used `http:` or `https:`, but returned the *raw* user-supplied string rather than the parsed URL string. This allowed URL parser differentials where the string passed validation but downstream consumers interpreted it as a different, potentially malicious URI.
 **Learning:** Checking a parsed URL is not enough if you continue to use the raw, un-normalized string. You must use the sanitized, serialized output of the parser (`parsedUrl.href`) to ensure the validation logic accurately reflects what the downstream consumer will process.
 **Prevention:** Always extract and export the canonicalized properties (`parsedUrl.href`) from the parsed URL object rather than returning the raw input string.
+## 2025-03-01 - [Incomplete Log Redaction via Exact Match]
+**Vulnerability:** The logger `provider/nanogpt-logger.ts` used an exact match (`Set.has()`) for redacting sensitive keys in JSON logs. This failed to catch keys with substrings like `providerApiKey` or `authToken`, potentially leaking secrets.
+**Learning:** Exact key matching for log redaction is insufficient and prone to data leaks, as developers frequently use variations or compound words for sensitive keys.
+**Prevention:** Use a case-insensitive regex substring match (`/apikey|token|password|secret|authorization|credential|cookie/i`) to redact any key containing these patterns, providing a more robust defense-in-depth approach.

--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -21,7 +21,10 @@ const NOOP_LOGGER: NanoGptLogger = {
 let _stream: ReturnType<typeof createWriteStream> | null = null;
 let _streamPromise: Promise<void> | null = null;
 
-function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; ready: Promise<void> } | null {
+function getOrCreateStream(): {
+  stream: ReturnType<typeof createWriteStream>;
+  ready: Promise<void>;
+} | null {
   if (_stream) {
     return { stream: _stream, ready: _streamPromise ?? Promise.resolve() };
   }
@@ -58,19 +61,10 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
-const SENSITIVE_KEYS = new Set([
-  "apikey",
-  "nanogptapikey",
-  "token",
-  "password",
-  "secret",
-  "authorization",
-  "credential",
-  "cookie",
-]);
+const SENSITIVE_KEYS_PATTERN = /apikey|token|password|secret|authorization|credential|cookie/i;
 
 function redactReplacer(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+  if (SENSITIVE_KEYS_PATTERN.test(key)) {
     return "[REDACTED]";
   }
   return value;
@@ -80,7 +74,12 @@ function formatTimestamp(): string {
   return new Date().toISOString();
 }
 
-function formatLogLine(level: NanoGptLogLevel, module: string, message: string, meta?: Record<string, unknown>): string {
+function formatLogLine(
+  level: NanoGptLogLevel,
+  module: string,
+  message: string,
+  meta?: Record<string, unknown>,
+): string {
   const timestamp = formatTimestamp();
   let metaStr = "";
   if (meta && Object.keys(meta).length > 0) {


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix incomplete log redaction via exact match

🚨 Severity: MEDIUM
💡 Vulnerability: The logger used exact matching for sensitive keys, which could leak secrets if keys had different names (e.g., `providerApiKey`).
🎯 Impact: Potential exposure of sensitive data (like API keys and tokens) in logs.
🔧 Fix: Updated the redaction logic to use a case-insensitive regex substring match.
✅ Verification: Checked log redaction functionality and ran tests.

---
*PR created automatically by Jules for task [15169136760962285431](https://jules.google.com/task/15169136760962285431) started by @deadronos*