### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance sensitive data redaction in logger

### DIFF
--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -58,19 +58,12 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
-const SENSITIVE_KEYS = new Set([
-  "apikey",
-  "nanogptapikey",
-  "token",
-  "password",
-  "secret",
-  "authorization",
-  "credential",
-  "cookie",
-]);
-
 function redactReplacer(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+  // Allow common safe token metrics explicitly to prevent over-redaction
+  if (/^(?:prompt|completion|total)_tokens$/i.test(key)) {
+    return value;
+  }
+  if (/apikey|token|password|secret|authorization|credential|cookie/i.test(key)) {
     return "[REDACTED]";
   }
   return value;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Enhance sensitive data redaction in logger

🚨 Severity: MEDIUM
💡 Vulnerability: The log redaction mechanism (`redactReplacer` in `provider/nanogpt-logger.ts`) relied on exact string matching via a `Set` for sensitive keys. This meant that compound keys (e.g., `providerApiKey`, `sessionToken`) containing sensitive terms were not redacted.
🎯 Impact: Sensitive secrets, credentials, or API keys could inadvertently be written to log files if they are passed within compound keys in the metadata object.
🔧 Fix: Upgraded the redaction mechanism to use a case-insensitive regex that performs substring matching. Crucially, explicitly excluded safe, common token metrics (`prompt_tokens`, `completion_tokens`, `total_tokens`) to prevent over-redaction and loss of observability data.
✅ Verification: Ran `pnpm test` and `pnpm lint` successfully. Verified that no regressions were introduced.

---
*PR created automatically by Jules for task [9472998058868920106](https://jules.google.com/task/9472998058868920106) started by @deadronos*