### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix compound key leakage in log redaction

### DIFF
--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -21,7 +21,10 @@ const NOOP_LOGGER: NanoGptLogger = {
 let _stream: ReturnType<typeof createWriteStream> | null = null;
 let _streamPromise: Promise<void> | null = null;
 
-function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; ready: Promise<void> } | null {
+function getOrCreateStream(): {
+  stream: ReturnType<typeof createWriteStream>;
+  ready: Promise<void>;
+} | null {
   if (_stream) {
     return { stream: _stream, ready: _streamPromise ?? Promise.resolve() };
   }
@@ -58,19 +61,14 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
-const SENSITIVE_KEYS = new Set([
-  "apikey",
-  "nanogptapikey",
-  "token",
-  "password",
-  "secret",
-  "authorization",
-  "credential",
-  "cookie",
-]);
+const SENSITIVE_KEYS_PATTERN = /apikey|token|password|secret|authorization|credential|cookie/i;
+const SAFE_TOKEN_METRICS = new Set(["prompt_tokens", "completion_tokens", "total_tokens"]);
 
 function redactReplacer(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+  if (SAFE_TOKEN_METRICS.has(key.toLowerCase())) {
+    return value;
+  }
+  if (SENSITIVE_KEYS_PATTERN.test(key)) {
     return "[REDACTED]";
   }
   return value;
@@ -80,7 +78,12 @@ function formatTimestamp(): string {
   return new Date().toISOString();
 }
 
-function formatLogLine(level: NanoGptLogLevel, module: string, message: string, meta?: Record<string, unknown>): string {
+function formatLogLine(
+  level: NanoGptLogLevel,
+  module: string,
+  message: string,
+  meta?: Record<string, unknown>,
+): string {
   const timestamp = formatTimestamp();
   let metaStr = "";
   if (meta && Object.keys(meta).length > 0) {


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix compound key leakage in log redaction

🚨 Severity: MEDIUM
💡 Vulnerability: The log redactor used exact set matching (`SENSITIVE_KEYS.has(...)`) to mask sensitive keys in log metadata. This allowed compound keys containing sensitive substrings (like `providerApiKey` or `sessionToken`) to bypass redaction and leak secrets into logs.
🎯 Impact: Sensitive data (like API keys and passwords) embedded in compound object keys could be written in plaintext to log files.
🔧 Fix: Updated `redactReplacer` to use case-insensitive regex substring matching (`/apikey|token|password|secret|authorization|credential|cookie/i`) and implemented an explicit allowlist for safe operational keys (like `prompt_tokens`).
✅ Verification: Ran `pnpm test` successfully (excluding the known pre-existing failure in `openclaw-discovery.test.ts`).

---
*PR created automatically by Jules for task [17400525966881470407](https://jules.google.com/task/17400525966881470407) started by @deadronos*