### PR TITLE
🛡️ Sentinel: [HIGH] Fix log redaction to catch compound sensitive keys

### DIFF
--- a/provider/nanogpt-logger.test.ts
+++ b/provider/nanogpt-logger.test.ts
@@ -37,6 +37,10 @@ describe("nanogpt logger", () => {
       nanoGptApiKey: "secret-nanogpt-key",
       nested: { token: "secret-token", password: "secret-password" },
       authorization: "secret-auth",
+      providerApiKey: "secret-provider-key",
+      prompt_tokens: 150,
+      completion_tokens: 50,
+      total_tokens: 200,
     });
 
     await new Promise((r) => setTimeout(r, 100));
@@ -55,6 +59,11 @@ describe("nanogpt logger", () => {
     expect(contents).not.toContain("secret-token");
     expect(contents).not.toContain("secret-password");
     expect(contents).not.toContain("secret-auth");
+    expect(contents).toContain('"providerApiKey":"[REDACTED]"');
+    expect(contents).not.toContain("secret-provider-key");
+    expect(contents).toContain('"prompt_tokens":150');
+    expect(contents).toContain('"completion_tokens":50');
+    expect(contents).toContain('"total_tokens":200');
   });
 
   it("handles circular references in metadata gracefully without throwing and writes the message", async () => {
@@ -85,9 +94,8 @@ describe("nanogpt logger", () => {
       };
     });
 
-    const { createNanoGptLoggerSync: createLoggerWithFailingFs } = await import(
-      "./nanogpt-logger.js"
-    );
+    const { createNanoGptLoggerSync: createLoggerWithFailingFs } =
+      await import("./nanogpt-logger.js");
     const log = createLoggerWithFailingFs("readonly-home");
 
     expect(() => {
@@ -112,9 +120,8 @@ describe("nanogpt logger", () => {
       };
     });
 
-    const { createNanoGptLoggerSync: createLoggerWithFailingFs } = await import(
-      "./nanogpt-logger.js"
-    );
+    const { createNanoGptLoggerSync: createLoggerWithFailingFs } =
+      await import("./nanogpt-logger.js");
     const log = createLoggerWithFailingFs("readonly-file");
 
     expect(() => {

--- a/provider/nanogpt-logger.ts
+++ b/provider/nanogpt-logger.ts
@@ -21,7 +21,10 @@ const NOOP_LOGGER: NanoGptLogger = {
 let _stream: ReturnType<typeof createWriteStream> | null = null;
 let _streamPromise: Promise<void> | null = null;
 
-function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; ready: Promise<void> } | null {
+function getOrCreateStream(): {
+  stream: ReturnType<typeof createWriteStream>;
+  ready: Promise<void>;
+} | null {
   if (_stream) {
     return { stream: _stream, ready: _streamPromise ?? Promise.resolve() };
   }
@@ -58,19 +61,11 @@ function getOrCreateStream(): { stream: ReturnType<typeof createWriteStream>; re
   return { stream, ready: _streamPromise };
 }
 
-const SENSITIVE_KEYS = new Set([
-  "apikey",
-  "nanogptapikey",
-  "token",
-  "password",
-  "secret",
-  "authorization",
-  "credential",
-  "cookie",
-]);
+const SENSITIVE_KEY_PATTERN = /apikey|token|password|secret|authorization|credential|cookie/i;
+const SAFE_TOKEN_METRICS = new Set(["prompt_tokens", "completion_tokens", "total_tokens"]);
 
 function redactReplacer(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+  if (!SAFE_TOKEN_METRICS.has(key) && SENSITIVE_KEY_PATTERN.test(key)) {
     return "[REDACTED]";
   }
   return value;
@@ -80,7 +75,12 @@ function formatTimestamp(): string {
   return new Date().toISOString();
 }
 
-function formatLogLine(level: NanoGptLogLevel, module: string, message: string, meta?: Record<string, unknown>): string {
+function formatLogLine(
+  level: NanoGptLogLevel,
+  module: string,
+  message: string,
+  meta?: Record<string, unknown>,
+): string {
   const timestamp = formatTimestamp();
   let metaStr = "";
   if (meta && Object.keys(meta).length > 0) {


### PR DESCRIPTION
Fixes a sensitive data leak in the log redactor.

The previous exact-match approach for redacting sensitive keys failed to catch compound keys, leading to the potential exposure of things like `providerApiKey`.

The fix implements a more robust regex-based substring matching approach, while explicitly allowing standard safe token metrics (`prompt_tokens`, `completion_tokens`, `total_tokens`) to ensure operational analytics are preserved. Tests have been fully updated.

---
*PR created automatically by Jules for task [9379698294616627652](https://jules.google.com/task/9379698294616627652) started by @deadronos*