### PR TITLE
🛡️ Sentinel: [HIGH] Fix predictable temporary file names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Case-insensitive exact matching logic (`SENSITIVE_KEYS.has(key.toLowerCase())`) fails to match compound keys (like `providerApiKey`, `nanoGptApiKey`), potentially polluting logs with leaked secrets.
 **Learning:** To ensure robust redaction for compound or dynamic keys containing sensitive patterns, use a regular expression test (`SENSITIVE_PATTERN.test(key)`) with case-insensitivity. Crucially, when using substrings to redact, you must explicitly exclude safe metrics like LLM token counts (`prompt_tokens`, `completion_tokens`, `total_tokens`), otherwise they might get incorrectly redacted by loose match patterns like `token`.
 **Prevention:** Implement a replacer function for `JSON.stringify` that explicitely checks keys against an allowlist for known-safe items (e.g. `SAFE_METRICS.has(key)`), then falls back to case-insensitive substring regex matching (`/apikey|token|password/i`) for redaction.
+## 2026-06-25 - [Predictable Temporary File Names]
+**Vulnerability:** The codebase was using `Math.random()` to generate temporary file paths, which is predictable and insecure.
+**Learning:** `Math.random()` is not cryptographically secure and predictable values can lead to symlink or collision attacks in temporary directories.
+**Prevention:** Always use cryptographically secure methods like `crypto.randomUUID()` or `crypto.randomBytes()` from `node:crypto` to generate temporary file names or any other random values used in security-sensitive contexts.

--- a/provider/discovery-persistence.ts
+++ b/provider/discovery-persistence.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
@@ -140,7 +141,7 @@ export function writeNanogptProviderCatalogToModelsJson(
 
   try {
     fs.mkdirSync(params.agentDir, { recursive: true });
-    const tmpPath = `${modelsPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tmpPath = `${modelsPath}.tmp-${process.pid}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
     fs.writeFileSync(tmpPath, `${JSON.stringify({ providers }, null, 2)}\n`);
     fs.renameSync(tmpPath, modelsPath);
     return { ok: true, changed, path: modelsPath };


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** The codebase was using `Math.random()` to generate temporary file paths, which is predictable and insecure.
**Impact:** `Math.random()` is not cryptographically secure and predictable values can lead to symlink or collision attacks in temporary directories.
**Fix:** Added `import crypto from "node:crypto";` and replaced `Math.random().toString(36).slice(2, 8)` with `crypto.randomUUID().slice(0, 8)` in `provider/discovery-persistence.ts`.
**Verification:** Ran `pnpm test` and `pnpm lint` and confirmed that everything is still working.

---
*PR created automatically by Jules for task [17009224877280177937](https://jules.google.com/task/17009224877280177937) started by @deadronos*