### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix predictable temporary file names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Case-insensitive exact matching logic (`SENSITIVE_KEYS.has(key.toLowerCase())`) fails to match compound keys (like `providerApiKey`, `nanoGptApiKey`), potentially polluting logs with leaked secrets.
 **Learning:** To ensure robust redaction for compound or dynamic keys containing sensitive patterns, use a regular expression test (`SENSITIVE_PATTERN.test(key)`) with case-insensitivity. Crucially, when using substrings to redact, you must explicitly exclude safe metrics like LLM token counts (`prompt_tokens`, `completion_tokens`, `total_tokens`), otherwise they might get incorrectly redacted by loose match patterns like `token`.
 **Prevention:** Implement a replacer function for `JSON.stringify` that explicitely checks keys against an allowlist for known-safe items (e.g. `SAFE_METRICS.has(key)`), then falls back to case-insensitive substring regex matching (`/apikey|token|password/i`) for redaction.
+## 2026-06-05 - Predictable Temporary File Name Vulnerability
+**Vulnerability:** The function `writeNanogptProviderCatalogToModelsJson` used `Math.random()` to generate a suffix for temporary file names.
+**Learning:** `Math.random()` does not provide cryptographically secure randomness, making temporary file names predictable and susceptible to symlink or collision attacks.
+**Prevention:** Always use `crypto.randomUUID()` or `crypto.randomBytes()` from the native `node:crypto` module when generating temporary file paths to ensure secure randomness.

--- a/provider/discovery-persistence.ts
+++ b/provider/discovery-persistence.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
@@ -140,7 +141,7 @@ export function writeNanogptProviderCatalogToModelsJson(
 
   try {
     fs.mkdirSync(params.agentDir, { recursive: true });
-    const tmpPath = `${modelsPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tmpPath = `${modelsPath}.tmp-${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
     fs.writeFileSync(tmpPath, `${JSON.stringify({ providers }, null, 2)}\n`);
     fs.renameSync(tmpPath, modelsPath);
     return { ok: true, changed, path: modelsPath };


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The function `writeNanogptProviderCatalogToModelsJson` used `Math.random()` to generate suffixes for temporary file names.
🎯 Impact: `Math.random()` does not provide cryptographically secure randomness, making temporary file names predictable and susceptible to symlink or collision attacks.
🔧 Fix: Updated the code to use `crypto.randomBytes(4).toString("hex")` from the native `node:crypto` module to ensure secure randomness when generating temporary file paths.
✅ Verification: Ran `pnpm format`, `pnpm lint`, and verified tests with `pnpm test -- provider/discovery-persistence.test.ts`. Also added a journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11532042504978600307](https://jules.google.com/task/11532042504978600307) started by @deadronos*