### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk in web search domain filters

### DIFF
--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -196,6 +196,64 @@ describe("nanogpt web search provider", () => {
     expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
   });
 
+  it("rejects overly long include domain strings", async () => {
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "test-key",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const longDomain = "a".repeat(256);
+    await expect(tool.execute({ query: "docs", includeDomains: [longDomain] })).rejects.toThrow(
+      "Include domain is too long (maximum 255 characters)."
+    );
+    expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects overly long exclude domain strings", async () => {
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "test-key",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const longDomain = "a".repeat(256);
+    await expect(tool.execute({ query: "docs", excludeDomains: [longDomain] })).rejects.toThrow(
+      "Exclude domain is too long (maximum 255 characters)."
+    );
+    expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
+  });
+
   it("normalizes NanoGPT search results and forwards domain filters through the trusted helper", async () => {
     postTrustedWebToolsJsonMock.mockImplementation(
       async (

--- a/web-search.ts
+++ b/web-search.ts
@@ -140,6 +140,12 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         if (excludeDomains && excludeDomains.length > 50) {
           throw new Error("Too many exclude domains specified (maximum 50).");
         }
+        if (includeDomains && includeDomains.some(d => d.length > 255)) {
+          throw new Error("Include domain is too long (maximum 255 characters).");
+        }
+        if (excludeDomains && excludeDomains.some(d => d.length > 255)) {
+          throw new Error("Exclude domain is too long (maximum 255 characters).");
+        }
 
         return await postTrustedWebToolsJson(
           {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `includeDomains` and `excludeDomains` arrays in the `web-search.ts` module lacked a maximum string length limit for individual array elements, allowing excessively large strings to be processed.
🎯 Impact: An attacker could pass massive strings to exhaust memory during JSON serialization or upstream API processing (Denial of Service).
🔧 Fix: Added validation to throw an error if any domain string exceeds 255 characters.
✅ Verification: Added corresponding tests in `web-search.test.ts` to ensure overly long domain inputs are rejected. All tests pass successfully.

---
*PR created automatically by Jules for task [7830329038991843461](https://jules.google.com/task/7830329038991843461) started by @deadronos*