### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion via unbounded domain lengths

### DIFF
--- a/web-search.test.ts
+++ b/web-search.test.ts
@@ -196,6 +196,64 @@ describe("nanogpt web search provider", () => {
     expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
   });
 
+  it("rejects include domains that exceed the maximum length", async () => {
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "test-key",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const longDomain = "a".repeat(256) + ".com";
+    await expect(
+      tool.execute({ query: "test", includeDomains: [longDomain] }),
+    ).rejects.toThrow("Include domain is too long (maximum 255 characters).");
+    expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects exclude domains that exceed the maximum length", async () => {
+    const provider = createNanoGptWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            nanogpt: {
+              config: {
+                webSearch: {
+                  apiKey: "test-key",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const longDomain = "a".repeat(256) + ".com";
+    await expect(
+      tool.execute({ query: "test", excludeDomains: [longDomain] }),
+    ).rejects.toThrow("Exclude domain is too long (maximum 255 characters).");
+    expect(postTrustedWebToolsJsonMock).not.toHaveBeenCalled();
+  });
+
   it("normalizes NanoGPT search results and forwards domain filters through the trusted helper", async () => {
     postTrustedWebToolsJsonMock.mockImplementation(
       async (

--- a/web-search.ts
+++ b/web-search.ts
@@ -39,6 +39,7 @@ const NANOGPT_WEB_SEARCH_SCHEMA = {
       items: {
         type: "string",
         minLength: 1,
+        maxLength: 255,
       },
     },
     excludeDomains: {
@@ -47,6 +48,7 @@ const NANOGPT_WEB_SEARCH_SCHEMA = {
       items: {
         type: "string",
         minLength: 1,
+        maxLength: 255,
       },
     },
   },
@@ -139,6 +141,12 @@ export function createNanoGptWebSearchProvider(): WebSearchProviderPlugin {
         }
         if (excludeDomains && excludeDomains.length > 50) {
           throw new Error("Too many exclude domains specified (maximum 50).");
+        }
+        if (includeDomains?.some((domain) => domain.length > 255)) {
+          throw new Error("Include domain is too long (maximum 255 characters).");
+        }
+        if (excludeDomains?.some((domain) => domain.length > 255)) {
+          throw new Error("Exclude domain is too long (maximum 255 characters).");
         }
 
         return await postTrustedWebToolsJson(


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unbounded array string inputs. The `web-search` tool accepts arrays of domain names (`includeDomains`, `excludeDomains`) and limits the array size to 50 items, but it did not restrict the length of individual string elements within the arrays.
🎯 **Impact:** Potential resource exhaustion (DoS) or unexpected payload bloat when an attacker supplies exceptionally long strings (e.g., megabytes of text disguised as domain names).
🔧 **Fix:** Enforced a `maxLength: 255` in the JSON schema for both properties, and added defensive runtime validation in `execute()` to throw if any element exceeds 255 characters (the standard limit for a DNS domain).
✅ **Verification:** Verified by unit tests added in `web-search.test.ts` ensuring that domain strings exceeding 255 characters are rejected cleanly.

---
*PR created automatically by Jules for task [6295186755993521088](https://jules.google.com/task/6295186755993521088) started by @deadronos*